### PR TITLE
fix(skills): retain dynamic grouped tools

### DIFF
--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/hook/skills/SkillsAgentHook.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/hook/skills/SkillsAgentHook.java
@@ -139,9 +139,7 @@ public class SkillsAgentHook extends AgentHook {
 	@Override
 	public List<ModelInterceptor> getModelInterceptors() {
 		SkillsInterceptor.Builder interceptorBuilder = SkillsInterceptor.builder().skillRegistry(this.skillRegistry);
-		if (!this.groupedTools.isEmpty()) {
-			interceptorBuilder.groupedTools(this.groupedTools);
-		}
+		interceptorBuilder.groupedTools(this.groupedTools);
 		if (this.toolCallbackResolver != null) {
 			interceptorBuilder.toolCallbackResolver(this.toolCallbackResolver);
 		}

--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/interceptors/SkillsInterceptorEnhancementsTest.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/interceptors/SkillsInterceptorEnhancementsTest.java
@@ -45,6 +45,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.List.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -153,6 +154,20 @@ class SkillsInterceptorEnhancementsTest {
 
 		assertEquals(1, toolCallbacks.size());
 		assertEquals("duplicate_tool", toolCallbacks.get(0).getToolDefinition().name());
+	}
+
+	@Test
+	void hookRetainsInitiallyEmptyGroupedToolsForLaterUpdates() {
+		Map<String, List<ToolCallback>> groupedTools = new ConcurrentHashMap<>();
+		SkillsAgentHook hook = SkillsAgentHook.builder().skillRegistry(registry).groupedTools(groupedTools).build();
+		SkillsInterceptor interceptor = (SkillsInterceptor) hook.getModelInterceptors().get(0);
+		assertTrue(interceptor.getGroupedTools().isEmpty());
+
+		ToolCallback tool = FunctionToolCallback.builder("late_tool", args -> "ok")
+				.description("Tool added after agent construction").inputType(String.class).build();
+		groupedTools.put("allowed-tools-test", List.of(tool));
+		assertEquals("late_tool", interceptor.getGroupedTools().get("allowed-tools-test").get(0)
+				.getToolDefinition().name());
 	}
 
 }


### PR DESCRIPTION
## What does this PR do?

The SkillsAgentHook currently skips configuring `groupedTools` when the map is empty at construction time. This makes an externally managed map ineffective when tools are added later.

Always passing the configured map to `SkillsInterceptor` preserves the live map reference. A regression test covers an initially empty `ConcurrentHashMap` populated after the hook is created.

This is the same fix discussed in alibaba/spring-ai-alibaba#4929, per maintainer guidance.

## Verification

- `git diff --check` passes.
- The test was added to `SkillsInterceptorEnhancementsTest`.
