### PR TITLE
chore(ci): run checks only on main

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,15 +18,11 @@ on:
   push:
     branches:
       - main
-      - 2.x
     paths-ignore:
       - '**.md'
-  pull_request:
-    branches:
-      - main
-      - 2.x
-    paths-ignore:
-      - '**.md'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 env:
   ENABLE_TEST_CI: true
 permissions:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -18,11 +18,9 @@ on:
   push:
     branches:
       - main
-      - 2.x
-  pull_request:
-    branches:
-      - main
-      - 2.x
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   license-check:
     if: (github.repository == 'agentic-spring-ai/agentic-spring-ai')

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,11 +18,9 @@ on:
   push:
     branches:
       - main
-      - 2.x
-  pull_request:
-    branches:
-      - main
-      - 2.x
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/secret-check.yml
+++ b/.github/workflows/secret-check.yml
@@ -18,11 +18,9 @@ on:
   push:
     branches:
       - main
-      - 2.x
-  pull_request:
-    branches:
-      - main
-      - 2.x
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   secret-check:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary
- run build, license, lint, and secret checks only after changes reach main
- stop resource-heavy CI on pull request events and 2.x pushes
- cancel superseded main-branch runs to conserve Actions capacity

## Validation
- parsed all four workflow files with Ruby YAML parser
- git diff --check passed

## Rollback
Revert commit bb053aa71 to restore the previous triggers.