### PR TITLE
fix: make Docker execution mounts readable

### DIFF
--- a/spring-boot-starters/agentic-spring-ai-starter-builtin-nodes/src/main/java/io/github/agentic/spring/ai/graph/utils/FileUtils.java
+++ b/spring-boot-starters/agentic-spring-ai-starter-builtin-nodes/src/main/java/io/github/agentic/spring/ai/graph/utils/FileUtils.java
@@ -24,6 +24,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
@@ -175,10 +176,23 @@ public class FileUtils {
 		try {
 			Path root = Path.of(workDir).toAbsolutePath().normalize();
 			Files.createDirectories(root);
-			return Files.createTempDirectory(root, ".agentic-exec-");
+			Path executionDirectory = Files.createTempDirectory(root, ".agentic-exec-");
+			makeContainerReadable(executionDirectory);
+			return executionDirectory;
 		}
 		catch (IOException e) {
 			throw new RuntimeException("Failed to create isolated execution directory", e);
+		}
+	}
+
+	private static void makeContainerReadable(Path executionDirectory) throws IOException {
+		try {
+			// The container drops DAC_OVERRIDE, so the bind mount must be traversable by
+			// a UID that differs from the host process owner.
+			Files.setPosixFilePermissions(executionDirectory, PosixFilePermissions.fromString("rwxr-xr-x"));
+		}
+		catch (UnsupportedOperationException ignored) {
+			// Non-POSIX hosts do not expose Unix mode bits to the container runtime.
 		}
 	}
 

--- a/spring-boot-starters/agentic-spring-ai-starter-builtin-nodes/src/test/java/io/github/agentic/spring/ai/graph/node/code/DockerCodeExecutorTest.java
+++ b/spring-boot-starters/agentic-spring-ai-starter-builtin-nodes/src/test/java/io/github/agentic/spring/ai/graph/node/code/DockerCodeExecutorTest.java
@@ -243,28 +243,29 @@ class DockerCodeExecutorTest {
 	@EnabledIf(value = "isCI", disabledReason = "this test is designed to run only in the GitHub CI environment.")
 	@Test
 	void testPython3Sum() throws Exception {
-		// 1. 构造 DockerCodeExecutor
+		// Create the Docker code executor.
 		DockerCodeExecutor executor = new DockerCodeExecutor();
 
-		// 2. 构造代码块（Python3 求和）
+		// Create a Python code block that sums its inputs.
 		String code = """
 				def main(inputs):
 				    return {\"result\": sum(inputs)}
 				""";
 		CodeBlock codeBlock = new CodeBlock("python3", code);
 
-		// 3. 构造执行配置
+		// Configure the execution environment.
 		Path workDir = Files.createTempDirectory("docker-code-exec-test");
 		CodeExecutionConfig config = new CodeExecutionConfig().setDocker("python:3.10")
 			.setWorkDir(workDir.toAbsolutePath().toString())
 			.setContainerName("docker-code-exec-test")
+			.setDockerHost(System.getenv().getOrDefault("DOCKER_HOST", "unix:///var/run/docker.sock"))
 			.setTimeout(60);
 
-		// 4. 执行
+		// Execute the code block.
 		CodeExecutionResult result = executor.executeCodeBlocks(List.of(codeBlock), config);
 
-		// 5. 断言
-		assertEquals(0, result.exitCode(), "Exit code should be 0");
+		// Verify that the container completed successfully.
+		assertEquals(0, result.exitCode(), () -> "Container logs: " + result.logs());
 	}
 
 }

--- a/spring-boot-starters/agentic-spring-ai-starter-builtin-nodes/src/test/java/io/github/agentic/spring/ai/graph/utils/FileUtilsTest.java
+++ b/spring-boot-starters/agentic-spring-ai-starter-builtin-nodes/src/test/java/io/github/agentic/spring/ai/graph/utils/FileUtilsTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
@@ -62,6 +63,10 @@ class FileUtilsTest {
 		Path first = FileUtils.createExecutionDirectory(tempDir.toString());
 		Path second = FileUtils.createExecutionDirectory(tempDir.toString());
 		assertNotEquals(first, second);
+		if (Files.getFileStore(first).supportsFileAttributeView("posix")) {
+			assertTrue(Files.getPosixFilePermissions(first).contains(PosixFilePermission.OTHERS_EXECUTE));
+			assertTrue(Files.getPosixFilePermissions(first).contains(PosixFilePermission.OTHERS_READ));
+		}
 		Files.createDirectories(first.resolve("nested"));
 		Files.writeString(first.resolve("nested/code.py"), "print('ok')");
 


### PR DESCRIPTION
Makes isolated bind-mount directories traversable after dropping DAC_OVERRIDE while retaining the existing Docker restrictions. Improves CI-only Docker diagnostics, honors DOCKER_HOST, and replaces existing Chinese step comments with English. JDK 17 targeted tests passed: 6 tests, 0 failures, 1 CI-only test skipped locally. Checkstyle and git diff --check passed. Fixes main run 33291622156.