### PR TITLE
fix: expose object input schemas for filesystem tools

### DIFF
--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/extension/tools/filesystem/GlobTool.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/extension/tools/filesystem/GlobTool.java
@@ -32,6 +32,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 /**
  * Tool for finding files matching a glob pattern.
  */
@@ -61,9 +64,12 @@ public class GlobTool implements BiFunction<String, ToolContext, String> {
 	}
 
 	@Override
-	public String apply(
-			@ToolParam(description = "The glob pattern to match files") String pattern,
+	public String apply(@ToolParam(description = "The glob pattern to match files") String pattern,
 			ToolContext toolContext) {
+		return glob(pattern, toolContext);
+	}
+
+	private String glob(String pattern, ToolContext toolContext) {
 		try {
 			if (this.backend != null) {
 				return ListFilesTool.formatFileInfoPaths(this.backend.globInfo(pattern, "/"),
@@ -98,9 +104,26 @@ public class GlobTool implements BiFunction<String, ToolContext, String> {
 	}
 
 	public static ToolCallback createGlobToolCallback(String description, FilesystemBackend backend) {
-		return FunctionToolCallback.builder("glob", new GlobTool(backend))
+		BiFunction<GlobRequest, ToolContext, String> function =
+				(request, context) -> new GlobTool(backend).apply(request.pattern, context);
+		return FunctionToolCallback.builder("glob", function)
 				.description(description)
-				.inputType(String.class)
+				.inputType(GlobRequest.class)
 				.build();
+	}
+
+	/** Request structure for glob searches. */
+	public static class GlobRequest {
+
+		@JsonProperty(required = true)
+		@JsonPropertyDescription("The glob pattern to match files")
+		public String pattern;
+
+		public GlobRequest() {
+		}
+
+		public GlobRequest(String pattern) {
+			this.pattern = pattern;
+		}
 	}
 }

--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/extension/tools/filesystem/ListFilesTool.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/extension/tools/filesystem/ListFilesTool.java
@@ -38,6 +38,9 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 /**
  * Tool for listing files in a directory.
  */
@@ -64,9 +67,12 @@ public class ListFilesTool implements BiFunction<String, ToolContext, String> {
 	}
 
 	@Override
-	public String apply(
-			@ToolParam(description = "The directory path to list files from") String path,
+	public String apply(@ToolParam(description = "The directory path to list files from") String path,
 			ToolContext toolContext) {
+		return list(path, toolContext);
+	}
+
+	private String list(String path, ToolContext toolContext) {
 		try {
 			if (this.backend != null) {
 				if (!this.backend.isDirectory(path)) {
@@ -235,9 +241,26 @@ public class ListFilesTool implements BiFunction<String, ToolContext, String> {
 	}
 
 	public static ToolCallback createListFilesToolCallback(String description, FilesystemBackend backend) {
-		return FunctionToolCallback.builder("ls", new ListFilesTool(backend))
+		BiFunction<ListFilesRequest, ToolContext, String> function =
+				(request, context) -> new ListFilesTool(backend).apply(request.path, context);
+		return FunctionToolCallback.builder("ls", function)
 				.description(description)
-				.inputType(String.class)
+				.inputType(ListFilesRequest.class)
 				.build();
+	}
+
+	/** Request structure for listing a directory. */
+	public static class ListFilesRequest {
+
+		@JsonProperty(required = true)
+		@JsonPropertyDescription("The absolute directory path to list files from")
+		public String path;
+
+		public ListFilesRequest() {
+		}
+
+		public ListFilesRequest(String path) {
+			this.path = path;
+		}
 	}
 }

--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/extension/interceptor/FilesystemInterceptorTest.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/extension/interceptor/FilesystemInterceptorTest.java
@@ -99,8 +99,8 @@ class FilesystemInterceptorTest {
 			.readOnly(true)
 			.build();
 
-		String listed = tool(interceptor, "ls").call("\"/\"", new ToolContext(Collections.emptyMap()));
-		String globbed = tool(interceptor, "glob").call("\"**/*.txt\"", new ToolContext(Collections.emptyMap()));
+		String listed = tool(interceptor, "ls").call("{\"path\":\"/\"}", new ToolContext(Collections.emptyMap()));
+		String globbed = tool(interceptor, "glob").call("{\"pattern\":\"**/*.txt\"}", new ToolContext(Collections.emptyMap()));
 		String grep = tool(interceptor, "grep").call(
 				"{\"pattern\":\"needle\",\"path\":\"/\",\"glob\":\"*.txt\",\"output_mode\":\"content\"}",
 				new ToolContext(Collections.emptyMap()));
@@ -108,6 +108,19 @@ class FilesystemInterceptorTest {
 		assertTrue(listed.contains("/dir/"));
 		assertTrue(globbed.contains("/dir/inside.txt"));
 		assertTrue(grep.contains("/dir/inside.txt:1: needle"));
+	}
+
+	@Test
+	void filesystemListAndGlobCallbacksExposeObjectSchemas() {
+		FilesystemInterceptor interceptor = FilesystemInterceptor.builder().readOnly(true).build();
+
+		String lsSchema = tool(interceptor, "ls").getToolDefinition().inputSchema();
+		String globSchema = tool(interceptor, "glob").getToolDefinition().inputSchema();
+
+		assertTrue(lsSchema.contains("\"type\":\"object\""));
+		assertTrue(lsSchema.contains("\"path\""));
+		assertTrue(globSchema.contains("\"type\":\"object\""));
+		assertTrue(globSchema.contains("\"pattern\""));
 	}
 
 	@Test
@@ -119,9 +132,9 @@ class FilesystemInterceptorTest {
 			.readOnly(true)
 			.build();
 
-		String missing = tool(interceptor, "ls").call("\"/missing\"", new ToolContext(Collections.emptyMap()));
-		String file = tool(interceptor, "ls").call("\"/plain.txt\"", new ToolContext(Collections.emptyMap()));
-		String empty = tool(interceptor, "ls").call("\"/empty\"", new ToolContext(Collections.emptyMap()));
+		String missing = tool(interceptor, "ls").call("{\"path\":\"/missing\"}", new ToolContext(Collections.emptyMap()));
+		String file = tool(interceptor, "ls").call("{\"path\":\"/plain.txt\"}", new ToolContext(Collections.emptyMap()));
+		String empty = tool(interceptor, "ls").call("{\"path\":\"/empty\"}", new ToolContext(Collections.emptyMap()));
 
 		assertThat(missing).contains("Error: Directory not found: /missing").doesNotContain("Directory is empty");
 		assertThat(file).contains("Error: Directory not found: /plain.txt").doesNotContain("Directory is empty");


### PR DESCRIPTION
## What does this PR do?

Expose object-shaped input schemas for the filesystem interceptor's `ls` and `glob` callbacks.

Both callbacks previously used `String.class` as their input type, which generated a top-level string schema. Providers such as DeepSeek require tool parameters to be represented as an object and rejected these definitions with HTTP 400.

## Changes

- Add `ListFilesRequest` with required `path` property.
- Add `GlobRequest` with required `pattern` property.
- Keep the direct `ListFilesTool.apply(String, ToolContext)` and `GlobTool.apply(String, ToolContext)` APIs unchanged.
- Add regression coverage for generated schemas and object callback invocation.

## Verification

- `git diff --check` passes.
- `./mvnw -pl agentic-spring-ai-agent-framework -Dtest=FilesystemInterceptorTest test` could not start because the configured Maven repository terminated the TLS handshake while resolving the parent BOMs (`SSL peer shut down incorrectly`).
