### PR TITLE
fix(agent): use object schemas for filesystem tools

### DIFF
--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/extension/tools/filesystem/GlobTool.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/extension/tools/filesystem/GlobTool.java
@@ -32,6 +32,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 /**
  * Tool for finding files matching a glob pattern.
  */
@@ -98,9 +101,17 @@ public class GlobTool implements BiFunction<String, ToolContext, String> {
 	}
 
 	public static ToolCallback createGlobToolCallback(String description, FilesystemBackend backend) {
-		return FunctionToolCallback.builder("glob", new GlobTool(backend))
+		GlobTool tool = new GlobTool(backend);
+		BiFunction<GlobRequest, ToolContext, String> function =
+				(request, toolContext) -> tool.apply(request.pattern(), toolContext);
+		return FunctionToolCallback.builder("glob", function)
 				.description(description)
-				.inputType(String.class)
+				.inputType(GlobRequest.class)
 				.build();
+	}
+
+	public record GlobRequest(
+			@JsonProperty(required = true, value = "pattern")
+			@JsonPropertyDescription("The glob pattern to match files") String pattern) {
 	}
 }

--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/extension/tools/filesystem/ListFilesTool.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/extension/tools/filesystem/ListFilesTool.java
@@ -38,6 +38,9 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 /**
  * Tool for listing files in a directory.
  */
@@ -235,9 +238,17 @@ public class ListFilesTool implements BiFunction<String, ToolContext, String> {
 	}
 
 	public static ToolCallback createListFilesToolCallback(String description, FilesystemBackend backend) {
-		return FunctionToolCallback.builder("ls", new ListFilesTool(backend))
+		ListFilesTool tool = new ListFilesTool(backend);
+		BiFunction<ListFilesRequest, ToolContext, String> function =
+				(request, toolContext) -> tool.apply(request.path(), toolContext);
+		return FunctionToolCallback.builder("ls", function)
 				.description(description)
-				.inputType(String.class)
+				.inputType(ListFilesRequest.class)
 				.build();
+	}
+
+	public record ListFilesRequest(
+			@JsonProperty(required = true, value = "path")
+			@JsonPropertyDescription("The directory path to list files from") String path) {
 	}
 }

--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/extension/interceptor/FilesystemInterceptorTest.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/extension/interceptor/FilesystemInterceptorTest.java
@@ -99,8 +99,9 @@ class FilesystemInterceptorTest {
 			.readOnly(true)
 			.build();
 
-		String listed = tool(interceptor, "ls").call("\"/\"", new ToolContext(Collections.emptyMap()));
-		String globbed = tool(interceptor, "glob").call("\"**/*.txt\"", new ToolContext(Collections.emptyMap()));
+		String listed = tool(interceptor, "ls").call("{\"path\":\"/\"}", new ToolContext(Collections.emptyMap()));
+		String globbed = tool(interceptor, "glob")
+			.call("{\"pattern\":\"**/*.txt\"}", new ToolContext(Collections.emptyMap()));
 		String grep = tool(interceptor, "grep").call(
 				"{\"pattern\":\"needle\",\"path\":\"/\",\"glob\":\"*.txt\",\"output_mode\":\"content\"}",
 				new ToolContext(Collections.emptyMap()));
@@ -119,13 +120,30 @@ class FilesystemInterceptorTest {
 			.readOnly(true)
 			.build();
 
-		String missing = tool(interceptor, "ls").call("\"/missing\"", new ToolContext(Collections.emptyMap()));
-		String file = tool(interceptor, "ls").call("\"/plain.txt\"", new ToolContext(Collections.emptyMap()));
-		String empty = tool(interceptor, "ls").call("\"/empty\"", new ToolContext(Collections.emptyMap()));
+		String missing = tool(interceptor, "ls")
+			.call("{\"path\":\"/missing\"}", new ToolContext(Collections.emptyMap()));
+		String file = tool(interceptor, "ls")
+			.call("{\"path\":\"/plain.txt\"}", new ToolContext(Collections.emptyMap()));
+		String empty = tool(interceptor, "ls")
+			.call("{\"path\":\"/empty\"}", new ToolContext(Collections.emptyMap()));
 
 		assertThat(missing).contains("Error: Directory not found: /missing").doesNotContain("Directory is empty");
 		assertThat(file).contains("Error: Directory not found: /plain.txt").doesNotContain("Directory is empty");
 		assertThat(empty).contains("Directory is empty").doesNotContain("Directory not found");
+	}
+
+	@Test
+	void listAndGlobToolsExposeObjectInputSchemas() {
+		FilesystemInterceptor interceptor = FilesystemInterceptor.builder().readOnly(true).build();
+
+		assertThat(tool(interceptor, "ls").getToolDefinition().inputSchema())
+			.contains("\"type\" : \"object\"")
+			.contains("\"path\"")
+			.contains("\"required\" : [ \"path\" ]");
+		assertThat(tool(interceptor, "glob").getToolDefinition().inputSchema())
+			.contains("\"type\" : \"object\"")
+			.contains("\"pattern\"")
+			.contains("\"required\" : [ \"pattern\" ]");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- expose object input schemas for filesystem `ls` and `glob` tools
- preserve the direct string-based tool APIs while adapting callback deserialization
- cover generated schemas and object argument execution

## Verification
- `./mvnw -pl agentic-spring-ai-agent-framework -am -Dtest=FilesystemInterceptorTest -Dsurefire.failIfNoSpecifiedTests=false test`
- 11 tests passed; Checkstyle and Spotless passed

Fixes #52

Related to alibaba/spring-ai-alibaba#4937.