### PR TITLE
fix: use object input schema for ls and glob filesystem tools

### DIFF
--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/extension/tools/filesystem/GlobTool.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/extension/tools/filesystem/GlobTool.java
@@ -17,9 +17,10 @@ package io.github.agentic.spring.ai.graph.agent.extension.tools.filesystem;
 
 import io.github.agentic.spring.ai.graph.agent.extension.file.FilesystemBackend;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.ToolCallback;
-import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 
 import java.io.IOException;
@@ -35,7 +36,7 @@ import java.util.function.BiFunction;
 /**
  * Tool for finding files matching a glob pattern.
  */
-public class GlobTool implements BiFunction<String, ToolContext, String> {
+public class GlobTool implements BiFunction<GlobTool.GlobRequest, ToolContext, String> {
 
 	private final FilesystemBackend backend;
 
@@ -61,9 +62,8 @@ public class GlobTool implements BiFunction<String, ToolContext, String> {
 	}
 
 	@Override
-	public String apply(
-			@ToolParam(description = "The glob pattern to match files") String pattern,
-			ToolContext toolContext) {
+	public String apply(GlobRequest request, ToolContext toolContext) {
+		String pattern = request.pattern;
 		try {
 			if (this.backend != null) {
 				return ListFilesTool.formatFileInfoPaths(this.backend.globInfo(pattern, "/"),
@@ -100,7 +100,24 @@ public class GlobTool implements BiFunction<String, ToolContext, String> {
 	public static ToolCallback createGlobToolCallback(String description, FilesystemBackend backend) {
 		return FunctionToolCallback.builder("glob", new GlobTool(backend))
 				.description(description)
-				.inputType(String.class)
+				.inputType(GlobRequest.class)
 				.build();
+	}
+
+	/**
+	 * Request structure for glob pattern matching.
+	 */
+	public static class GlobRequest {
+
+		@JsonProperty(required = true, value = "pattern")
+		@JsonPropertyDescription("The glob pattern to match files")
+		public String pattern;
+
+		public GlobRequest() {
+		}
+
+		public GlobRequest(String pattern) {
+			this.pattern = pattern;
+		}
 	}
 }

--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/extension/tools/filesystem/ListFilesTool.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/extension/tools/filesystem/ListFilesTool.java
@@ -18,9 +18,10 @@ package io.github.agentic.spring.ai.graph.agent.extension.tools.filesystem;
 import io.github.agentic.spring.ai.graph.agent.extension.file.FileInfo;
 import io.github.agentic.spring.ai.graph.agent.extension.file.FilesystemBackend;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.tool.ToolCallback;
-import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.ai.tool.function.FunctionToolCallback;
 
 import java.io.IOException;
@@ -41,7 +42,7 @@ import java.util.stream.Stream;
 /**
  * Tool for listing files in a directory.
  */
-public class ListFilesTool implements BiFunction<String, ToolContext, String> {
+public class ListFilesTool implements BiFunction<ListFilesTool.ListFilesRequest, ToolContext, String> {
 
 	private final FilesystemBackend backend;
 
@@ -64,9 +65,8 @@ public class ListFilesTool implements BiFunction<String, ToolContext, String> {
 	}
 
 	@Override
-	public String apply(
-			@ToolParam(description = "The directory path to list files from") String path,
-			ToolContext toolContext) {
+	public String apply(ListFilesRequest request, ToolContext toolContext) {
+		String path = request.path;
 		try {
 			if (this.backend != null) {
 				return formatFileInfoPaths(this.backend.lsInfo(path), "Directory is empty");
@@ -234,7 +234,24 @@ public class ListFilesTool implements BiFunction<String, ToolContext, String> {
 	public static ToolCallback createListFilesToolCallback(String description, FilesystemBackend backend) {
 		return FunctionToolCallback.builder("ls", new ListFilesTool(backend))
 				.description(description)
-				.inputType(String.class)
+				.inputType(ListFilesRequest.class)
 				.build();
+	}
+
+	/**
+	 * Request structure for listing files.
+	 */
+	public static class ListFilesRequest {
+
+		@JsonProperty(required = true, value = "path")
+		@JsonPropertyDescription("The directory path to list files from")
+		public String path;
+
+		public ListFilesRequest() {
+		}
+
+		public ListFilesRequest(String path) {
+			this.path = path;
+		}
 	}
 }


### PR DESCRIPTION
Closes #52

## Summary

Wrap `ListFilesTool` and `GlobTool` single string parameters in request classes (`ListFilesRequest`, `GlobRequest`) with `@JsonProperty` annotations so the generated JSON schema is `type: object` instead of `type: string`.

## Problem

Both tools used `.inputType(String.class)` which produces a top-level JSON schema with `type: "string"`. Providers like DeepSeek reject tool definitions that require `type: "object"`, returning HTTP 400.

## Changes

| Tool | Request class | Property |
|------|--------------|----------|
| ls | `ListFilesRequest` | `path` (required) |
| glob | `GlobRequest` | `pattern` (required) |

This matches the pattern used by `ReadFileTool`, `WriteFileTool`, `EditFileTool`, and `GrepTool` in the same package.

## Notes

- `ListFilesTool.listFilesContent()` and `ListFilesTool.formatFileInfoPaths()` static methods are unchanged — callers like `FileSystemTools` are not affected
- The public API remains backward compatible; only the JSON schema exposed to LLMs changes