### PR TITLE
fix(agent): resolve dynamically disclosed skill tools after HITL resumption (#35)

### DIFF
--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/DefaultBuilder.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/DefaultBuilder.java
@@ -45,6 +45,8 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class DefaultBuilder extends Builder {
 
@@ -138,6 +140,12 @@ public class DefaultBuilder extends Builder {
 			llmNodeBuilder.enableReasoningLog(true);
 		}
 
+		// Shared in-memory registry for tool callbacks disclosed dynamically at model-call
+		// time. AgentLlmNode fills it; AgentToolNode falls back to it when the config context
+		// no longer carries the callbacks (e.g. after a Human-in-the-Loop resumption).
+		Map<String, ToolCallback> dynamicToolCallbacksRegistry = new ConcurrentHashMap<>();
+		llmNodeBuilder.dynamicToolCallbacksRegistry(dynamicToolCallbacksRegistry);
+
 		AgentLlmNode llmNode = llmNodeBuilder.build();
 
 		// Setup tool node with all available tools
@@ -147,7 +155,8 @@ public class DefaultBuilder extends Builder {
 				.parallelToolExecution(this.parallelToolExecution)
 				.maxParallelTools(this.maxParallelTools)
 				.toolExecutionTimeout(this.toolExecutionTimeout)
-				.wrapSyncToolsAsAsync(this.wrapSyncToolsAsAsync);
+				.wrapSyncToolsAsAsync(this.wrapSyncToolsAsAsync)
+				.dynamicToolCallbacksRegistry(dynamicToolCallbacksRegistry);
 
 		if (resolver != null) {
 			toolBuilder.toolCallbackResolver(resolver);

--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/node/AgentLlmNode.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/node/AgentLlmNode.java
@@ -74,6 +74,13 @@ public class AgentLlmNode implements NodeActionWithConfig {
 	// FIXME: toolCallbacks should be managed in chatOptions only. Currently it's guaranteed immutable with unmodifiableList.
 	private List<ToolCallback> toolCallbacks = new ArrayList<>();
 
+	/**
+	 * Shared in-memory registry (with {@link AgentToolNode}) of tool callbacks disclosed
+	 * dynamically at model-call time. It keeps the callbacks resolvable after a
+	 * Human-in-the-Loop resumption, where the config context is cleared.
+	 */
+	private Map<String, ToolCallback> dynamicToolCallbacksRegistry;
+
 	private List<ModelInterceptor> modelInterceptors = new ArrayList<>();
 
 	private List<StreamingModelInterceptor> streamingInterceptors = new ArrayList<>();
@@ -107,6 +114,7 @@ public class AgentLlmNode implements NodeActionWithConfig {
 		if (builder.toolCallbacks != null) {
 			this.toolCallbacks = builder.toolCallbacks;
 		}
+		this.dynamicToolCallbacksRegistry = builder.dynamicToolCallbacksRegistry;
 		if (builder.modelInterceptors != null) {
 			this.modelInterceptors = builder.modelInterceptors;
 		}
@@ -492,6 +500,7 @@ public class AgentLlmNode implements NodeActionWithConfig {
 			filteredToolCallbacks = ToolCallbackUtils.deduplicateByName(filteredToolCallbacks, dynamicToolCallbacks);
 			// FIXME, use RunnableConfig to pass dynamic tool callbacks to tool node via config context (internal use)
 			config.context().put(RunnableConfig.DYNAMIC_TOOL_CALLBACKS_METADATA_KEY, dynamicToolCallbacks);
+			registerDynamicToolCallbacks(dynamicToolCallbacks);
 		}
 		else {
 			config.context().remove(RunnableConfig.DYNAMIC_TOOL_CALLBACKS_METADATA_KEY);
@@ -514,6 +523,16 @@ public class AgentLlmNode implements NodeActionWithConfig {
         return promptSpec;
 	}
 
+	private void registerDynamicToolCallbacks(List<ToolCallback> dynamicToolCallbacks) {
+		if (dynamicToolCallbacksRegistry == null) {
+			return;
+		}
+		dynamicToolCallbacksRegistry.clear();
+		for (ToolCallback callback : dynamicToolCallbacks) {
+			dynamicToolCallbacksRegistry.put(callback.getToolDefinition().name(), callback);
+		}
+	}
+
 	public String getName() {
 		return AGENT_MODEL_NAME;
 	}
@@ -534,6 +553,8 @@ public class AgentLlmNode implements NodeActionWithConfig {
 		private List<Advisor> advisors;
 
 		private List<ToolCallback> toolCallbacks;
+
+		private Map<String, ToolCallback> dynamicToolCallbacksRegistry;
 
 		private List<ModelInterceptor> modelInterceptors;
 
@@ -577,6 +598,11 @@ public class AgentLlmNode implements NodeActionWithConfig {
 
 		public Builder toolCallbacks(List<ToolCallback> toolCallbacks) {
 			this.toolCallbacks = toolCallbacks;
+			return this;
+		}
+
+		public Builder dynamicToolCallbacksRegistry(Map<String, ToolCallback> dynamicToolCallbacksRegistry) {
+			this.dynamicToolCallbacksRegistry = dynamicToolCallbacksRegistry;
 			return this;
 		}
 

--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/node/AgentToolNode.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/node/AgentToolNode.java
@@ -121,6 +121,15 @@ public class AgentToolNode implements NodeActionWithConfig {
 
 	private ToolExecutionExceptionProcessor toolExecutionExceptionProcessor;
 
+	/**
+	 * In-memory registry of tool callbacks disclosed dynamically at model-call time
+	 * (e.g. skill tools injected by a progressive-disclosure model interceptor). The same
+	 * compiled graph instance is reused when a run resumes after a Human-in-the-Loop
+	 * interruption, so this registry survives resumption even though
+	 * {@code config.context()} is cleared.
+	 */
+	private final Map<String, ToolCallback> dynamicToolCallbacks;
+
 	public AgentToolNode(Builder builder) {
 		this.agentName = builder.agentName;
 		this.enableActingLog = builder.enableActingLog;
@@ -128,6 +137,8 @@ public class AgentToolNode implements NodeActionWithConfig {
 		this.toolCallbacks = builder.toolCallbacks;
 		this.toolContext = builder.toolContext;
 		this.toolExecutionExceptionProcessor = builder.toolExecutionExceptionProcessor;
+		this.dynamicToolCallbacks = builder.dynamicToolCallbacksRegistry != null ? builder.dynamicToolCallbacksRegistry
+				: new ConcurrentHashMap<>();
 		this.parallelToolExecution = builder.parallelToolExecution;
 		this.maxParallelTools = builder.maxParallelTools;
 		this.toolExecutionTimeout = builder.toolExecutionTimeout;
@@ -144,6 +155,24 @@ public class AgentToolNode implements NodeActionWithConfig {
 
 	void setToolCallbackResolver(ToolCallbackResolver toolCallbackResolver) {
 		this.toolCallbackResolver = toolCallbackResolver;
+	}
+
+	/**
+	 * Registers tool callbacks disclosed dynamically (for example by a progressive-disclosure
+	 * model interceptor) so they stay resolvable when a run resumes after an interruption and
+	 * {@code config.context()} no longer carries them. Called by {@link AgentLlmNode} whenever
+	 * it computes the dynamic tool callbacks for a model call.
+	 */
+	void registerDynamicToolCallbacks(List<ToolCallback> callbacks) {
+		dynamicToolCallbacks.clear();
+		if (callbacks == null) {
+			return;
+		}
+		for (ToolCallback callback : callbacks) {
+			if (callback != null) {
+				dynamicToolCallbacks.put(callback.getToolDefinition().name(), callback);
+			}
+		}
 	}
 
 	public List<ToolCallback> getToolCallbacks() {
@@ -852,6 +881,13 @@ public class AgentToolNode implements NodeActionWithConfig {
 		if (fromDynamic != null) {
 			return fromDynamic;
 		}
+		// Fall back to the in-memory registry populated by AgentLlmNode: the config context is
+		// cleared when a subgraph resumes after a Human-in-the-Loop interruption, while the
+		// registry lives on the reused compiled graph instance.
+		ToolCallback fromRegistry = dynamicToolCallbacks.get(toolName);
+		if (fromRegistry != null) {
+			return fromRegistry;
+		}
 		return toolCallbackResolver == null ? null : toolCallbackResolver.resolve(toolName);
 	}
 
@@ -891,6 +927,8 @@ public class AgentToolNode implements NodeActionWithConfig {
 		private List<ToolCallback> toolCallbacks = new ArrayList<>();
 
 		private Map<String, Object> toolContext = new HashMap<>();
+
+		private Map<String, ToolCallback> dynamicToolCallbacksRegistry;
 
 		private ToolCallbackResolver toolCallbackResolver;
 
@@ -976,6 +1014,11 @@ public class AgentToolNode implements NodeActionWithConfig {
 
 		public Builder toolCallbackResolver(ToolCallbackResolver toolCallbackResolver) {
 			this.toolCallbackResolver = toolCallbackResolver;
+			return this;
+		}
+
+		public Builder dynamicToolCallbacksRegistry(Map<String, ToolCallback> dynamicToolCallbacksRegistry) {
+			this.dynamicToolCallbacksRegistry = dynamicToolCallbacksRegistry;
 			return this;
 		}
 

--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/node/AgentToolNodeDynamicToolCallbackRegistryTest.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/node/AgentToolNodeDynamicToolCallbackRegistryTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.agentic.spring.ai.graph.agent.node;
+
+import io.github.agentic.spring.ai.graph.OverAllState;
+import io.github.agentic.spring.ai.graph.RunnableConfig;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.execution.ToolExecutionExceptionProcessor;
+import org.springframework.ai.tool.function.FunctionToolCallback;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the in-memory dynamic tool callback registry on {@link AgentToolNode}.
+ *
+ * <p>
+ * Covers the Human-in-the-Loop resumption scenario reported in issue #35: skill tools are
+ * disclosed dynamically at model-call time and passed to the tool node through
+ * {@code config.context()}, which is cleared when a subgraph resumes after an interruption.
+ * The registry (shared with {@link AgentLlmNode} via the agent builder) keeps the disclosed
+ * callbacks resolvable across resumption.
+ * </p>
+ *
+ * @author Kal'tsit
+ * @since 1.0.0
+ */
+@DisplayName("AgentToolNode Dynamic Tool Callback Registry Tests")
+class AgentToolNodeDynamicToolCallbackRegistryTest {
+
+	private static final ToolExecutionExceptionProcessor DEFAULT_PROCESSOR = e -> "Error: " + e.getMessage();
+
+	private ToolCallback queryTool() {
+		return FunctionToolCallback.builder("queryTool", (QueryInput input) -> "result:" + input.q())
+			.description("Query tool")
+			.inputType(QueryInput.class)
+			.build();
+	}
+
+	record QueryInput(String q) {
+	}
+
+	private AgentToolNode buildNode() {
+		return AgentToolNode.builder()
+			.agentName("test-agent")
+			.toolExecutionTimeout(Duration.ofMinutes(5))
+			.toolExecutionExceptionProcessor(DEFAULT_PROCESSOR)
+			.build();
+	}
+
+	private OverAllState stateWithToolCall(String toolName, String arguments) {
+		AssistantMessage assistantMessage = AssistantMessage.builder()
+			.content("")
+			.toolCalls(List.of(new AssistantMessage.ToolCall("call_1", "function", toolName, arguments)))
+			.build();
+		Map<String, Object> stateData = new HashMap<>();
+		stateData.put("messages", new ArrayList<>(List.of(assistantMessage)));
+		return new OverAllState(stateData);
+	}
+
+	@Test
+	@DisplayName("Dynamic registry resolves a tool when the config context is empty (HITL resume scenario)")
+	void dynamicRegistryResolvesToolWhenConfigContextIsEmpty() throws Exception {
+		AgentToolNode node = buildNode();
+		node.registerDynamicToolCallbacks(List.of(queryTool()));
+
+		// Simulate a resumed run: a fresh config whose context no longer carries the
+		// dynamically disclosed tool callbacks.
+		RunnableConfig config = RunnableConfig.builder().threadId("test-thread").build();
+
+		Map<String, Object> result = node.apply(stateWithToolCall("queryTool", "{\"q\":\"hello\"}"), config);
+
+		ToolResponseMessage responseMessage = (ToolResponseMessage) result.get("messages");
+		assertThat(responseMessage.getResponses()).hasSize(1);
+		assertThat(responseMessage.getResponses().get(0).responseData()).contains("result:hello");
+	}
+
+	@Test
+	@DisplayName("A tool absent from the registry is reported as unavailable")
+	void toolAbsentFromRegistryIsReportedUnavailable() throws Exception {
+		AgentToolNode node = buildNode();
+
+		RunnableConfig config = RunnableConfig.builder().threadId("test-thread").build();
+
+		Map<String, Object> result = node.apply(stateWithToolCall("unknownTool", "{}"), config);
+
+		ToolResponseMessage responseMessage = (ToolResponseMessage) result.get("messages");
+		assertThat(responseMessage.getResponses()).hasSize(1);
+		assertThat(responseMessage.getResponses().get(0).responseData()).contains("Tool not available: unknownTool");
+	}
+
+}


### PR DESCRIPTION
## 改动
- AgentLlmNode 与 AgentToolNode 之间增加共享的进程内动态工具回调注册表（由 DefaultBuilder 创建并注入两个节点）；
- AgentLlmNode 在模型调用时把渐进式披露的动态回调（如 SkillsInterceptor 注入的 skill 工具）同步写入注册表；
- AgentToolNode.resolve() 在 config context 缺失时回退到注册表查找。

## 原因
动态工具回调此前只通过 config.context() 传递（AgentLlmNode 中有 FIXME 标记）。子图在 Human-in-the-Loop 中断后恢复时，GraphRunnerContext 会清空 context，导致 AgentToolNode 无法解析已获人工确认的工具，Skills 场景下报 "No ToolCallback found for tool name: queryTool"（issue #35，源自 alibaba/spring-ai-alibaba#4606）。

注册表挂在节点实例上：恢复执行复用同一个 CompiledGraph，节点实例存活，因此回调在恢复后可解析，且不涉及 checkpoint 状态序列化。

## 验证
- 新增 AgentToolNodeDynamicToolCallbackRegistryTest：
  - 空 context + 注册表 → 工具正常执行并返回结果；
  - 无注册表条目 → 工具按现有逻辑报告不可用。
- 本地回归：AgentToolCallingAdvisorBoundaryTest 等 6 个用例通过。

Fixes #35