### PR TITLE
fix(graph): fall back to a fresh start when a resume config has no checkpoint (#28)

### DIFF
--- a/agentic-spring-ai-graph-core/src/main/java/io/github/agentic/spring/ai/graph/GraphRunnerContext.java
+++ b/agentic-spring-ai-graph-core/src/main/java/io/github/agentic/spring/ai/graph/GraphRunnerContext.java
@@ -96,8 +96,15 @@ public class GraphRunnerContext {
 
 		var saver = compiledGraph.compileConfig.checkpointSaver()
 				.orElseThrow(() -> new IllegalStateException("Resume request without a configured checkpoint saver!"));
-		var checkpoint = saver.get(config)
-				.orElseThrow(() -> new IllegalStateException("Resume request without a valid checkpoint!"));
+		var checkpointOptional = saver.get(config);
+		if (checkpointOptional.isEmpty()) {
+			// 多 agent 编排下，父图恢复时只有被中断的子 agent 有 checkpoint；其它子 agent
+			// 从未中断、没有 checkpoint，应作为新会话初始化而不是抛异常。
+			log.debug("Resume config present but no checkpoint found for this (sub)graph; falling back to fresh start.");
+			initializeFromStart(initialState, config);
+			return;
+		}
+		var checkpoint = checkpointOptional.get();
 
 		var startCheckpointNextNodeAction = compiledGraph.getNodeAction(checkpoint.getNextNodeId());
 		if (startCheckpointNextNodeAction instanceof ResumableSubGraphAction resumableAction) {

--- a/agentic-spring-ai-graph-core/src/test/java/io/github/agentic/spring/ai/graph/GraphRunnerContextResumeWithoutCheckpointTest.java
+++ b/agentic-spring-ai-graph-core/src/test/java/io/github/agentic/spring/ai/graph/GraphRunnerContextResumeWithoutCheckpointTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.agentic.spring.ai.graph;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.github.agentic.spring.ai.graph.StateGraph.START;
+import static io.github.agentic.spring.ai.graph.action.AsyncNodeActionWithConfig.node_async;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Regression tests for issue #28: in multi-agent orchestration, resuming the parent graph
+ * after a Human-in-the-Loop interruption carries {@code HUMAN_FEEDBACK} metadata into every
+ * sibling sub-agent. Sub-agents that were never interrupted have no checkpoint, and the
+ * resume path used to fail with {@code IllegalStateException: Resume request without a
+ * valid checkpoint!}. They must fall back to a fresh start instead.
+ */
+@DisplayName("GraphRunnerContext resume without checkpoint tests")
+class GraphRunnerContextResumeWithoutCheckpointTest {
+
+	@Test
+	@DisplayName("Resume config without a checkpoint falls back to fresh start instead of throwing")
+	void resumeConfigWithoutCheckpointFallsBackToFreshStart() throws Exception {
+		StateGraph graph = new StateGraph();
+		graph.addNode("nodeA", node_async((state, config) -> Map.<String, Object>of()));
+		graph.addEdge(START, "nodeA");
+
+		CompiledGraph compiledGraph = graph.compile();
+		OverAllState state = new OverAllState(Map.of());
+		RunnableConfig resumeConfig = RunnableConfig.builder()
+			.threadId("thread-without-checkpoint")
+			.addMetadata(RunnableConfig.HUMAN_FEEDBACK_METADATA_KEY, "placeholder")
+			.build();
+
+		assertThatCode(() -> new GraphRunnerContext(state, resumeConfig, compiledGraph))
+			.doesNotThrowAnyException();
+	}
+
+}


### PR DESCRIPTION
## 改动
- GraphRunnerContext.initializeFromResume：配置带 HUMAN_FEEDBACK 或 checkPointId、但当前（子）图没有 checkpoint 时，回退为新会话初始化，不再抛出 "Resume request without a valid checkpoint!"。

## 原因
多 agent 编排下，父图因某个子 agent 的 Human-in-the-Loop 中断而恢复时，恢复配置会携带 HUMAN_FEEDBACK metadata；其它从未中断、从未产生 checkpoint 的子 agent 也会进入 resume 初始化路径，导致加载 checkpoint 异常（issue #28，源自 alibaba/spring-ai-alibaba#4115）。

## 验证
- 新增 GraphRunnerContextResumeWithoutCheckpointTest：无 checkpoint 的恢复配置不再抛异常、按新会话初始化；
- 本地编译与测试通过。

Fixes #28
