### PR TITLE
fix(agent): prevent duplicate instruction injection when ReactAgent runs as AgentTool

### DIFF
--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/AgentTool.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/AgentTool.java
@@ -20,7 +20,6 @@ import io.github.agentic.spring.ai.graph.RunnableConfig;
 import io.github.agentic.spring.ai.graph.agent.tool.StateAwareToolCallback;
 import io.github.agentic.spring.ai.graph.agent.tools.ToolContextHelper;
 import io.github.agentic.spring.ai.graph.exception.GraphRunnerException;
-import io.github.agentic.spring.ai.graph.serializer.AgentInstructionMessage;
 
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
@@ -197,14 +196,11 @@ public class AgentTool {
 			// The input parameter is wrapped as {"input": "actual_value"}
 			String actualInput = extractInputValue(input);
 
-			// Build the messages list to add
-			// Add instruction first if present, then the user input
-			// Note: We must add all messages at once because cloneState doesn't copy keyStrategies,
+			// Instruction is injected exactly once by the child agent's default
+			// InstructionAgentHook (see issue #77); only the user input is added here.
+			// Note: we add all messages at once because cloneState doesn't copy keyStrategies,
 			// so multiple updateState calls would overwrite instead of append
 			List<Message> messagesToAdd = new ArrayList<>();
-			if (StringUtils.hasLength(agent.instruction())) {
-				messagesToAdd.add(AgentInstructionMessage.builder().text(agent.instruction()).build());
-			}
 			messagesToAdd.add(new UserMessage(actualInput));
 
 			Optional<OverAllState> resultState;

--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/AgentTool.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/AgentTool.java
@@ -34,7 +34,6 @@ import org.springframework.ai.util.JsonHelper;
 import org.springframework.ai.util.json.schema.JsonSchemaGenerator;
 import org.springframework.util.StringUtils;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -198,10 +197,7 @@ public class AgentTool {
 
 			// Instruction is injected exactly once by the child agent's default
 			// InstructionAgentHook (see issue #77); only the user input is added here.
-			// Note: we add all messages at once because cloneState doesn't copy keyStrategies,
-			// so multiple updateState calls would overwrite instead of append
-			List<Message> messagesToAdd = new ArrayList<>();
-			messagesToAdd.add(new UserMessage(actualInput));
+			List<Message> messagesToAdd = List.of(new UserMessage(actualInput));
 
 			Optional<OverAllState> resultState;
 			Optional<RunnableConfig> parentConfigOpt = ToolContextHelper.getConfig(toolContext);

--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/hook/InstructionAgentHook.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/hook/InstructionAgentHook.java
@@ -26,25 +26,36 @@ import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * MessagesAgentHook that injects the ReactAgent's instruction into messages before each agent run.
  * <p>
  * When this hook is active, it runs at {@link HookPosition#BEFORE_AGENT} and reads
  * {@link ReactAgent#instruction()} from {@link #getAgent()}. If the instruction is non-empty,
- * it prepends an {@link AgentInstructionMessage} to the given messages and returns an
+ * it appends an {@link AgentInstructionMessage} to the given messages and returns an
  * {@link AgentCommand} with {@link io.github.agentic.spring.ai.graph.agent.hook.messages.UpdatePolicy#REPLACE}.
  * This allows ReactAgent to avoid adding instruction again in the subgraph adapter when used as a subgraph node.
  * <p>
- * The hook is idempotent: if the incoming messages already contain an identical
- * {@link AgentInstructionMessage} (e.g. placed there manually by a caller such as AgentTool),
- * it is not duplicated — the output keeps exactly one copy of the current instruction (issue #77).
+ * The hook is idempotent: a copy of this agent's own instruction is never duplicated. A copy is
+ * considered stale when it carries this agent's {@link #AGENT_NAME_METADATA_KEY} metadata (tagged by
+ * this hook; the tag survives template rendering and checkpoint serialization), or when it is an
+ * untagged copy with the exact same text (e.g. injected manually by a caller). Copies belonging to
+ * other agents are left untouched, so exactly one copy of the current instruction stays in the
+ * model context (issue #77).
  * <p>
  * This hook is added by default in ReactAgent when no other hook is an InstructionAgentHook.
  * It runs first among beforeAgent hooks (lowest order).
  */
 @HookPositions(HookPosition.BEFORE_AGENT)
 public class InstructionAgentHook extends MessagesAgentHook {
+
+	/**
+	 * Metadata key that marks an {@link AgentInstructionMessage} with the name of the agent that
+	 * injected it, so this hook can recognize its own copies even after template rendering has
+	 * changed their text.
+	 */
+	public static final String AGENT_NAME_METADATA_KEY = "instructionAgentName";
 
 	private ReactAgent reactAgent;
 
@@ -58,16 +69,27 @@ public class InstructionAgentHook extends MessagesAgentHook {
 			return new AgentCommand(previousMessages);
 		}
 		// Idempotent injection: keep exactly one copy of the current instruction even when
-		// a caller (e.g. AgentTool) already placed it into the messages (see issue #77).
+		// a caller already placed it into the messages (see issue #77).
 		List<Message> newMessages = new ArrayList<>();
 		for (Message message : previousMessages) {
-			if (message instanceof AgentInstructionMessage existing && instruction.equals(existing.getText())) {
+			if (message instanceof AgentInstructionMessage existing && isOwnStaleCopy(existing, instruction)) {
 				continue;
 			}
 			newMessages.add(message);
 		}
-		newMessages.add(AgentInstructionMessage.builder().text(instruction).build());
+		newMessages.add(AgentInstructionMessage.builder()
+				.text(instruction)
+				.metadata(Map.of(AGENT_NAME_METADATA_KEY, reactAgent.name()))
+				.build());
 		return new AgentCommand(newMessages);
+	}
+
+	private boolean isOwnStaleCopy(AgentInstructionMessage existing, String instruction) {
+		Map<String, Object> metadata = existing.getMetadata();
+		if (metadata != null && reactAgent.name().equals(metadata.get(AGENT_NAME_METADATA_KEY))) {
+			return true;
+		}
+		return instruction.equals(existing.getText());
 	}
 
 	@Override

--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/hook/InstructionAgentHook.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/hook/InstructionAgentHook.java
@@ -36,6 +36,10 @@ import java.util.List;
  * {@link AgentCommand} with {@link io.github.agentic.spring.ai.graph.agent.hook.messages.UpdatePolicy#REPLACE}.
  * This allows ReactAgent to avoid adding instruction again in the subgraph adapter when used as a subgraph node.
  * <p>
+ * The hook is idempotent: if the incoming messages already contain an identical
+ * {@link AgentInstructionMessage} (e.g. placed there manually by a caller such as AgentTool),
+ * it is not duplicated — the output keeps exactly one copy of the current instruction (issue #77).
+ * <p>
  * This hook is added by default in ReactAgent when no other hook is an InstructionAgentHook.
  * It runs first among beforeAgent hooks (lowest order).
  */
@@ -53,9 +57,16 @@ public class InstructionAgentHook extends MessagesAgentHook {
 		if (!StringUtils.hasLength(instruction)) {
 			return new AgentCommand(previousMessages);
 		}
-		AgentInstructionMessage instructionMessage = AgentInstructionMessage.builder().text(instruction).build();
-		List<Message> newMessages = new ArrayList<>(previousMessages);
-		newMessages.add(instructionMessage);
+		// Idempotent injection: keep exactly one copy of the current instruction even when
+		// a caller (e.g. AgentTool) already placed it into the messages (see issue #77).
+		List<Message> newMessages = new ArrayList<>();
+		for (Message message : previousMessages) {
+			if (message instanceof AgentInstructionMessage existing && instruction.equals(existing.getText())) {
+				continue;
+			}
+			newMessages.add(message);
+		}
+		newMessages.add(AgentInstructionMessage.builder().text(instruction).build());
 		return new AgentCommand(newMessages);
 	}
 

--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/hook/InstructionAgentHook.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/hook/InstructionAgentHook.java
@@ -86,9 +86,14 @@ public class InstructionAgentHook extends MessagesAgentHook {
 
 	private boolean isOwnStaleCopy(AgentInstructionMessage existing, String instruction) {
 		Map<String, Object> metadata = existing.getMetadata();
-		if (metadata != null && reactAgent.name().equals(metadata.get(AGENT_NAME_METADATA_KEY))) {
-			return true;
+		if (metadata != null && metadata.containsKey(AGENT_NAME_METADATA_KEY)) {
+			// Explicit ownership: an instruction attributed to another agent is never
+			// stale for this one, even when the rendered text is identical — dropping
+			// it would silently erase the other agent's instruction from a shared
+			// message history.
+			return reactAgent.name().equals(metadata.get(AGENT_NAME_METADATA_KEY));
 		}
+		// Legacy copies carry no ownership marker; text equality is the only signal.
 		return instruction.equals(existing.getText());
 	}
 

--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/Issue77DuplicateInstructionTest.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/Issue77DuplicateInstructionTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.agentic.spring.ai.graph.agent;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.github.agentic.spring.ai.graph.checkpoint.savers.MemorySaver;
+import io.github.agentic.spring.ai.graph.serializer.AgentInstructionMessage;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.model.ToolContext;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import reactor.core.publisher.Flux;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Reproduction for <a href="https://github.com/agentic-spring-ai/agentic-spring-ai/issues/77">issue #77</a>:
+ * when a ReactAgent with an instruction runs through {@link AgentTool}, the instruction used to be
+ * injected twice (once manually by the tool executor, once by the default InstructionAgentHook),
+ * so the model context carried two copies. It must appear exactly once.
+ */
+class Issue77DuplicateInstructionTest {
+
+	private static final String INSTRUCTION = "You are a product support assistant.";
+
+	private static class CapturingChatModel implements ChatModel {
+
+		final List<Prompt> prompts = new CopyOnWriteArrayList<>();
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			this.prompts.add(prompt);
+			return new ChatResponse(List.of(new Generation(new AssistantMessage("done"))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			this.prompts.add(prompt);
+			return Flux.just(new ChatResponse(List.of(new Generation(new AssistantMessage("done")))));
+		}
+
+	}
+
+	@Test
+	void instructionAppearsExactlyOnceWhenAgentRunsAsTool() {
+		CapturingChatModel model = new CapturingChatModel();
+		ReactAgent childAgent = ReactAgent.builder()
+				.name("issue77_child")
+				.model(model)
+				.saver(new MemorySaver())
+				.instruction(INSTRUCTION)
+				.build();
+
+		AgentTool.AgentToolExecutor executor = new AgentTool.AgentToolExecutor(childAgent);
+		AssistantMessage result = executor.executeAgent("{\"input\": \"hello\"}", new ToolContext(Map.of()));
+
+		assertNotNull(result);
+		long instructionCopies = model.prompts.stream()
+				.flatMap(prompt -> prompt.getInstructions().stream())
+				.filter(AgentInstructionMessage.class::isInstance)
+				.map(message -> ((AgentInstructionMessage) message).getText())
+				.filter(INSTRUCTION::equals)
+				.count();
+		assertEquals(1, instructionCopies, "instruction must appear exactly once in the model context");
+	}
+
+	@Test
+	void userMessageIsStillPassedThroughWhenInstructionIsInjectedOnce() {
+		CapturingChatModel model = new CapturingChatModel();
+		ReactAgent childAgent = ReactAgent.builder()
+				.name("issue77_child_user")
+				.model(model)
+				.saver(new MemorySaver())
+				.instruction(INSTRUCTION)
+				.build();
+
+		AgentTool.AgentToolExecutor executor = new AgentTool.AgentToolExecutor(childAgent);
+		executor.executeAgent("{\"input\": \"hello\"}", new ToolContext(Map.of()));
+
+		long userMessageCopies = model.prompts.stream()
+				.flatMap(prompt -> prompt.getInstructions().stream())
+				.filter(message -> message.getClass() == UserMessage.class)
+				.map(Message::getText)
+				.filter("hello"::equals)
+				.count();
+		assertEquals(1, userMessageCopies, "the user input must not be duplicated either");
+	}
+
+}

--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/Issue77DuplicateInstructionTest.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/Issue77DuplicateInstructionTest.java
@@ -15,10 +15,6 @@
  */
 package io.github.agentic.spring.ai.graph.agent;
 
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
-
 import io.github.agentic.spring.ai.graph.checkpoint.savers.MemorySaver;
 import io.github.agentic.spring.ai.graph.serializer.AgentInstructionMessage;
 
@@ -31,12 +27,17 @@ import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.model.ToolContext;
 import org.springframework.ai.chat.prompt.Prompt;
 
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
 import reactor.core.publisher.Flux;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Reproduction for <a href="https://github.com/agentic-spring-ai/agentic-spring-ai/issues/77">issue #77</a>:
@@ -80,13 +81,15 @@ class Issue77DuplicateInstructionTest {
 		AssistantMessage result = executor.executeAgent("{\"input\": \"hello\"}", new ToolContext(Map.of()));
 
 		assertNotNull(result);
-		long instructionCopies = model.prompts.stream()
-				.flatMap(prompt -> prompt.getInstructions().stream())
-				.filter(AgentInstructionMessage.class::isInstance)
-				.map(message -> ((AgentInstructionMessage) message).getText())
-				.filter(INSTRUCTION::equals)
-				.count();
-		assertEquals(1, instructionCopies, "instruction must appear exactly once in the model context");
+		assertTrue(!model.prompts.isEmpty(), "the child agent must call the model at least once");
+		for (Prompt prompt : model.prompts) {
+			long instructionCopies = prompt.getInstructions().stream()
+					.filter(AgentInstructionMessage.class::isInstance)
+					.map(message -> ((AgentInstructionMessage) message).getText())
+					.filter(INSTRUCTION::equals)
+					.count();
+			assertEquals(1, instructionCopies, "each model call must carry the instruction exactly once");
+		}
 	}
 
 	@Test

--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/hook/messages/InstructionAgentHookIdempotencyTest.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/hook/messages/InstructionAgentHookIdempotencyTest.java
@@ -30,6 +30,7 @@ import org.springframework.ai.chat.prompt.Prompt;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import reactor.core.publisher.Flux;
 
@@ -124,6 +125,25 @@ class InstructionAgentHookIdempotencyTest {
 
 		assertEquals(1, countInstruction(command.getMessages(), "other agent instruction"));
 		assertEquals(1, countInstruction(command.getMessages(), INSTRUCTION));
+	}
+
+	@Test
+	void renderedOwnCopyFromPreviousTurnIsReplacedByFreshInstruction() {
+		InstructionAgentHook hook = hookFor(INSTRUCTION);
+		// Simulate a previous turn: the hook injected the raw template, the model node rendered it
+		// in place (text mutated, rendered flag set, ownership metadata preserved).
+		List<Message> previous = new ArrayList<>(List.of(
+				AgentInstructionMessage.builder()
+						.text("You are a product support assistant for Bob.")
+						.metadata(Map.of(InstructionAgentHook.AGENT_NAME_METADATA_KEY, "instr-agent"))
+						.rendered(true)
+						.build(),
+				new UserMessage("hello")));
+
+		AgentCommand command = hook.beforeAgent(previous, null);
+
+		long total = command.getMessages().stream().filter(AgentInstructionMessage.class::isInstance).count();
+		assertEquals(1, total, "the stale rendered copy must be replaced by a single fresh instruction");
 	}
 
 }

--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/hook/messages/InstructionAgentHookIdempotencyTest.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/hook/messages/InstructionAgentHookIdempotencyTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.agentic.spring.ai.graph.agent.hook.messages;
+
+import io.github.agentic.spring.ai.graph.agent.ReactAgent;
+import io.github.agentic.spring.ai.graph.agent.hook.InstructionAgentHook;
+import io.github.agentic.spring.ai.graph.checkpoint.savers.MemorySaver;
+import io.github.agentic.spring.ai.graph.serializer.AgentInstructionMessage;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import reactor.core.publisher.Flux;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies the "exactly one instruction" invariant of {@link InstructionAgentHook}: when the
+ * incoming messages already carry the same instruction text (e.g. injected manually by a caller
+ * such as AgentTool, see issue #77), the hook must not append another copy.
+ */
+class InstructionAgentHookIdempotencyTest {
+
+	private static final String INSTRUCTION = "You are a product support assistant.";
+
+	private static class NoopChatModel implements ChatModel {
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			return new ChatResponse(List.of(new Generation(new AssistantMessage("mock"))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.empty();
+		}
+
+	}
+
+	private InstructionAgentHook hookFor(String instruction) {
+		ReactAgent agent = ReactAgent.builder()
+				.name("instr-agent")
+				.model(new NoopChatModel())
+				.saver(new MemorySaver())
+				.instruction(instruction)
+				.build();
+		InstructionAgentHook hook = InstructionAgentHook.create();
+		hook.setAgent(agent);
+		return hook;
+	}
+
+	private long countInstruction(List<Message> messages, String text) {
+		return messages.stream()
+				.filter(AgentInstructionMessage.class::isInstance)
+				.map(message -> ((AgentInstructionMessage) message).getText())
+				.filter(text::equals)
+				.count();
+	}
+
+	@Test
+	void duplicateSameTextInstructionIsNormalizedToSingleCopy() {
+		InstructionAgentHook hook = hookFor(INSTRUCTION);
+		List<Message> previous = new ArrayList<>(List.of(
+				AgentInstructionMessage.builder().text(INSTRUCTION).build(),
+				new UserMessage("hello"),
+				AgentInstructionMessage.builder().text(INSTRUCTION).build()));
+
+		AgentCommand command = hook.beforeAgent(previous, null);
+
+		assertEquals(1, countInstruction(command.getMessages(), INSTRUCTION));
+	}
+
+	@Test
+	void missingInstructionIsInjectedOnce() {
+		InstructionAgentHook hook = hookFor(INSTRUCTION);
+		List<Message> previous = new ArrayList<>(List.of(new UserMessage("hello")));
+
+		AgentCommand command = hook.beforeAgent(previous, null);
+
+		assertEquals(1, countInstruction(command.getMessages(), INSTRUCTION));
+	}
+
+	@Test
+	void agentWithoutInstructionLeavesMessagesUnchanged() {
+		InstructionAgentHook hook = hookFor("");
+		List<Message> previous = new ArrayList<>(List.of(new UserMessage("hello")));
+
+		AgentCommand command = hook.beforeAgent(previous, null);
+
+		assertEquals(previous, command.getMessages());
+	}
+
+	@Test
+	void differentTextInstructionIsKeptAndCurrentInstructionAppendedOnce() {
+		InstructionAgentHook hook = hookFor(INSTRUCTION);
+		List<Message> previous = new ArrayList<>(List.of(
+				AgentInstructionMessage.builder().text("other agent instruction").build(),
+				new UserMessage("hello")));
+
+		AgentCommand command = hook.beforeAgent(previous, null);
+
+		assertEquals(1, countInstruction(command.getMessages(), "other agent instruction"));
+		assertEquals(1, countInstruction(command.getMessages(), INSTRUCTION));
+	}
+
+}

--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/hook/messages/InstructionAgentHookIdempotencyTest.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/hook/messages/InstructionAgentHookIdempotencyTest.java
@@ -146,4 +146,37 @@ class InstructionAgentHookIdempotencyTest {
 		assertEquals(1, total, "the stale rendered copy must be replaced by a single fresh instruction");
 	}
 
+	@Test
+	void sameTextInstructionOwnedByAnotherAgentIsNeverRemoved() {
+		// A child agent sharing the parent's exact instruction text must not dedupe away
+		// the parent-owned copy from a shared message history: ownership metadata wins
+		// over text equality (review finding on the instruction dedup PR).
+		ReactAgent agent = ReactAgent.builder()
+				.name("child")
+				.model(new NoopChatModel())
+				.saver(new MemorySaver())
+				.instruction(INSTRUCTION)
+				.build();
+		InstructionAgentHook hook = InstructionAgentHook.create();
+		hook.setAgent(agent);
+
+		List<Message> previous = new ArrayList<>(List.of(
+				AgentInstructionMessage.builder()
+						.text(INSTRUCTION)
+						.metadata(Map.of(InstructionAgentHook.AGENT_NAME_METADATA_KEY, "parent"))
+						.build(),
+				new UserMessage("hello")));
+
+		AgentCommand command = hook.beforeAgent(previous, null);
+
+		long parentOwned = command.getMessages().stream()
+				.filter(AgentInstructionMessage.class::isInstance)
+				.filter(message -> "parent"
+						.equals(((AgentInstructionMessage) message).getMetadata().get(InstructionAgentHook.AGENT_NAME_METADATA_KEY)))
+				.count();
+		assertEquals(1, parentOwned, "the parent-owned instruction must survive the child's dedup");
+		assertEquals(2, countInstruction(command.getMessages(), INSTRUCTION),
+				"the retained parent copy plus exactly one fresh child copy");
+	}
+
 }


### PR DESCRIPTION
### Describe what this PR does / why we need it

When a ReactAgent with an instruction is exposed through `AgentTool`, the instruction ended up **twice** in the model context: once added manually by `AgentTool.executeAgent(...)`, and once by the default `InstructionAgentHook` that every ReactAgent registers. Because `AgentInstructionMessage` is `MessageType.USER` and the `AgentCommand` REPLACE policy does not deduplicate, both copies reached the model — and since rendering only handles the last one, the first could even stay an unrendered template.

This PR makes the hook the single instruction injector:

1. `InstructionAgentHook.beforeAgent(...)` is now idempotent — it strips same-text `AgentInstructionMessage` copies before appending a fresh one, so exactly one copy of the current instruction reaches the model on any code path.
2. `AgentTool.executeAgent(...)` no longer adds the instruction manually and only passes the user input, matching the existing convention in the subgraph adapter ("Instruction is always injected by InstructionAgentHook in beforeAgent; do not add here").

### Does this pull request fix one issue?

Fixes #77

### Describe how you did it

- `InstructionAgentHook.beforeAgent()`: drop previous `AgentInstructionMessage` instances whose text equals the current instruction before appending a fresh one. Instructions with different text (belonging to other agents) are left untouched; the empty-instruction pass-through behavior is unchanged.
- `AgentTool.executeAgent()`: removed the manual `AgentInstructionMessage` branch and the now-unused import.
- Tests:
  - `InstructionAgentHookIdempotencyTest` — 4 cases: duplicate normalization, single injection, no-instruction pass-through, different-text instruction kept.
  - `Issue77DuplicateInstructionTest` — end-to-end through `AgentTool.AgentToolExecutor` with a capturing `ChatModel`. Against the unfixed hook it reproduces the bug (`expected: <1> but was: <2>`); with this change it is green.

### Describe how to verify it

```
mvn -pl agentic-spring-ai-agent-framework -am test -Dtest='InstructionAgentHookIdempotencyTest,Issue77DuplicateInstructionTest'
```

Full module suite (`mvn -pl agentic-spring-ai-agent-framework -am test`) shows the same results as `main`; the only failures are the pre-existing Windows symlink-privilege tests in `FilesystemInterceptorTest` / `FileSystemToolsTest`, which fail identically on unmodified `main`.

### Special notes for reviewers

Found while porting alibaba/spring-ai-alibaba#4946 to this repository; the root cause was confirmed line-by-line at `dd0a640f7` before this change.
