### PR TITLE
fix(agent): rewind checkpoint to turn boundary on stream cancellation

### DIFF
--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/ReactAgent.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/ReactAgent.java
@@ -47,6 +47,8 @@ import io.github.agentic.spring.ai.graph.agent.interceptor.StreamingModelInterce
 import io.github.agentic.spring.ai.graph.agent.interceptor.ToolInterceptor;
 import io.github.agentic.spring.ai.graph.agent.node.AgentLlmNode;
 import io.github.agentic.spring.ai.graph.agent.node.AgentToolNode;
+import io.github.agentic.spring.ai.graph.checkpoint.BaseCheckpointSaver;
+import io.github.agentic.spring.ai.graph.checkpoint.Checkpoint;
 import io.github.agentic.spring.ai.graph.exception.GraphRunnerException;
 import io.github.agentic.spring.ai.graph.exception.GraphStateException;
 import io.github.agentic.spring.ai.graph.internal.node.Node;
@@ -299,6 +301,47 @@ public class ReactAgent extends BaseAgent {
 
 	public CompiledGraph getCompiledGraph() {
 		return compiledGraph;
+	}
+
+	@Override
+	protected Flux<NodeOutput> doStream(Map<String, Object> input, RunnableConfig runnableConfig) {
+		CompiledGraph compiledGraph = getAndCompileGraph();
+		RunnableConfig config = buildStreamConfig(runnableConfig);
+		Optional<BaseCheckpointSaver> saver = compiledGraph.compileConfig.checkpointSaver();
+		Optional<Checkpoint> preTurnCheckpoint = saver.flatMap(s -> {
+			try {
+				return s.get(config);
+			}
+			catch (Exception e) {
+				return Optional.empty();
+			}
+		});
+		return compiledGraph.stream(input, config)
+				.doOnCancel(() -> rewindToPreTurnCheckpoint(saver, config, preTurnCheckpoint));
+	}
+
+	/**
+	 * A cancelled streaming turn must not leave a half-persisted multi-step fragment (a dangling
+	 * assistant tool_call or an orphan tool response) in the checkpoint: the next turn would load
+	 * an invalid message sequence that LLM APIs reject. Rewind the thread to the checkpoint taken
+	 * before this turn started, so a cancelled turn is treated as if it never happened (issue #25).
+	 */
+	private void rewindToPreTurnCheckpoint(Optional<BaseCheckpointSaver> saver, RunnableConfig config,
+			Optional<Checkpoint> preTurnCheckpoint) {
+		if (saver.isEmpty()) {
+			return;
+		}
+		try {
+			// No pre-turn checkpoint means this was the first turn on the thread: rewind to an
+			// empty state so the cancelled turn leaves nothing behind.
+			Checkpoint rewindCheckpoint = preTurnCheckpoint.map(Checkpoint::copyOf)
+				.orElseGet(() -> Checkpoint.builder().nodeId(StateGraph.START).nextNodeId(StateGraph.END)
+						.state(new HashMap<>()).build());
+			saver.get().put(config, rewindCheckpoint);
+		}
+		catch (Exception e) {
+			// Rewinding is best-effort: a failure here must not mask the cancellation itself.
+		}
 	}
 
 	@Override

--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/ReactAgent.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/ReactAgent.java
@@ -71,6 +71,7 @@ import org.springframework.ai.tool.ToolCallback;
 
 import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.SignalType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -308,16 +309,34 @@ public class ReactAgent extends BaseAgent {
 		CompiledGraph compiledGraph = getAndCompileGraph();
 		RunnableConfig config = buildStreamConfig(runnableConfig);
 		Optional<BaseCheckpointSaver> saver = compiledGraph.compileConfig.checkpointSaver();
-		Optional<Checkpoint> preTurnCheckpoint = saver.flatMap(s -> {
-			try {
-				return s.get(config);
-			}
-			catch (Exception e) {
-				return Optional.empty();
-			}
+		// Capture the pre-turn snapshot at subscription time, not at assembly time:
+		// the graph itself only executes on subscribe, so the rewind base must be
+		// read in the same per-subscription scope. A snapshot taken when the Flux
+		// was created would let a cancellation roll the thread back over any state
+		// committed between assembly and subscription, and every re-subscription of
+		// a cold Flux would reuse that same stale read.
+		return Flux.defer(() -> {
+			Optional<Checkpoint> preTurnCheckpoint = saver.flatMap(s -> {
+				try {
+					return s.get(config);
+				}
+				catch (Exception e) {
+					return Optional.empty();
+				}
+			});
+			return compiledGraph.stream(input, config)
+					.doFinally(signal -> {
+						// Rewind in doFinally rather than doOnCancel: cancellation is
+						// cooperative, so the cancelled run may still persist one more
+						// checkpoint while unwinding. doFinally runs after the upstream
+						// has fully terminated, making the rewind the last writer for
+						// this execution instead of a write that a late checkpoint put
+						// can overwrite.
+						if (signal == SignalType.CANCEL) {
+							rewindToPreTurnCheckpoint(saver, config, preTurnCheckpoint);
+						}
+					});
 		});
-		return compiledGraph.stream(input, config)
-				.doOnCancel(() -> rewindToPreTurnCheckpoint(saver, config, preTurnCheckpoint));
 	}
 
 	/**

--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/Issue25StreamCancelCheckpointTest.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/Issue25StreamCancelCheckpointTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.agentic.spring.ai.graph.agent;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.github.agentic.spring.ai.graph.RunnableConfig;
+import io.github.agentic.spring.ai.graph.checkpoint.BaseCheckpointSaver;
+import io.github.agentic.spring.ai.graph.checkpoint.Checkpoint;
+import io.github.agentic.spring.ai.graph.checkpoint.savers.MemorySaver;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.ToolResponseMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.support.ToolCallbacks;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reproduction for <a href="https://github.com/agentic-spring-ai/agentic-spring-ai/issues/25">issue #25</a>:
+ * when a streaming run is cancelled mid-flight (client timeout, SSE disconnect), the persisted
+ * checkpoint may contain a {@link ToolResponseMessage} whose preceding assistant tool_call never
+ * made it into the checkpoint. The next turn then loads an invalid message sequence and the LLM
+ * rejects the request with 400.
+ */
+class Issue25StreamCancelCheckpointTest {
+
+	private static final class LookupTools {
+
+		@Tool(description = "look up something")
+		public String lookup(@ToolParam(description = "the query") String query) {
+			return "result-for-" + query;
+		}
+
+	}
+
+	private static final class ToolCallThenFinalChatModel implements ChatModel {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			if (callCount.incrementAndGet() == 1) {
+				AssistantMessage.ToolCall toolCall = new AssistantMessage.ToolCall("call-1", "function",
+						"lookup", "{\"query\": \"x\"}");
+				return new ChatResponse(List.of(new Generation(
+						AssistantMessage.builder().content("").toolCalls(List.of(toolCall)).build())));
+			}
+			return new ChatResponse(List.of(new Generation(new AssistantMessage("final answer"))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+
+	}
+
+	private ReactAgent agentWith(MemorySaver saver, String name) {
+		ToolCallback lookup = ToolCallbacks.from(new LookupTools())[0];
+		return ReactAgent.builder()
+				.name(name)
+				.model(new ToolCallThenFinalChatModel())
+				.tools(lookup)
+				.saver(new LoggingSaver(saver))
+				.build();
+	}
+
+	private static final class LoggingSaver implements BaseCheckpointSaver {
+
+		private final MemorySaver delegate;
+
+		LoggingSaver(MemorySaver delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public Optional<Checkpoint> get(RunnableConfig config) {
+			return delegate.get(config);
+		}
+
+		@Override
+		public Collection<Checkpoint> list(RunnableConfig config) {
+			return delegate.list(config);
+		}
+
+		@Override
+		public BaseCheckpointSaver.Tag release(RunnableConfig config) throws Exception {
+			return delegate.release(config);
+		}
+
+		@Override
+		public RunnableConfig put(RunnableConfig config, Checkpoint checkpoint) throws Exception {
+			Object messages = checkpoint.getState() == null ? null : checkpoint.getState().get("messages");
+			String desc = messages instanceof List<?> list
+					? list.stream().map(m -> m instanceof Message msg ? msg.getMessageType().name() : m.getClass().getSimpleName())
+							.reduce((a, b) -> a + "," + b).orElse("<empty>")
+					: String.valueOf(messages);
+			System.out.println("[T " + System.currentTimeMillis() + "] [PUT " + Thread.currentThread().getName()
+					+ "] id=" + checkpoint.getId().substring(0, 8) + " state=[" + desc + "]");
+			if (Thread.currentThread().getName().startsWith("boundedElastic")) {
+				for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
+					if (e.getClassName().contains("agentic") && !e.getClassName().contains("LoggingSaver")) {
+						System.out.println("    at " + e);
+					}
+				}
+			}
+			return delegate.put(config, checkpoint);
+		}
+
+	}
+
+
+	private Checkpoint checkpointOf(MemorySaver saver, RunnableConfig config) {
+		return saver.get(config).orElse(null);
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<Message> messagesOf(Checkpoint checkpoint) {
+		Object messages = checkpoint.getState().get("messages");
+		return messages instanceof List<?> list ? (List<Message>) list : List.of();
+	}
+
+	private void assertToolCallPairsValid(List<Message> messages) {
+		Message previous = null;
+		int toolCalls = 0;
+		int toolResponses = 0;
+		StringBuilder description = new StringBuilder();
+		for (Message message : messages) {
+			if (description.length() > 0) {
+				description.append(" -> ");
+			}
+			description.append(message.getMessageType());
+			if (message instanceof AssistantMessage assistant && !assistant.getToolCalls().isEmpty()) {
+				description.append("(tool_call)");
+			}
+			if (message instanceof ToolResponseMessage) {
+				toolResponses++;
+				description.append("(tool)");
+				assertTrue(previous instanceof AssistantMessage && !((AssistantMessage) previous).getToolCalls().isEmpty(),
+						"persisted sequence invalid: tool response preceded by " + previous + " in " + description);
+			}
+			if (message instanceof AssistantMessage assistant && !assistant.getToolCalls().isEmpty()) {
+				toolCalls++;
+			}
+			previous = message;
+		}
+		if (toolCalls != toolResponses) {
+			throw new AssertionError("assistant tool_call and tool response must be paired — expected " + toolCalls
+					+ " responses but was " + toolResponses + " in " + description);
+		}
+	}
+
+	private void assertToolCallPairsValid(Checkpoint checkpoint) {
+		assertToolCallPairsValid(messagesOf(checkpoint));
+	}
+
+	@Test
+	void fullStreamingRunPersistsValidSequence() throws Exception {
+		MemorySaver saver = new MemorySaver();
+		ReactAgent agent = agentWith(saver, "issue25_full_agent");
+		RunnableConfig config = RunnableConfig.builder().threadId("issue25-full").build();
+
+		List<Message> seen = agent.streamMessages(new UserMessage("please look up x"), config)
+				.collectList()
+				.block(Duration.ofSeconds(10));
+
+		assertNotNull(seen);
+		Checkpoint checkpoint = checkpointOf(saver, config);
+		assertNotNull(checkpoint, "a checkpoint must exist after a completed run");
+		assertToolCallPairsValid(checkpoint);
+	}
+
+	@Test
+	void cancelledStreamMustNotLeaveOrphanToolResponse() throws Exception {
+		MemorySaver saver = new MemorySaver();
+		ReactAgent agent = agentWith(saver, "issue25_cancel_agent");
+		RunnableConfig config = RunnableConfig.builder().threadId("issue25-cancel").build();
+
+		CountDownLatch firstEvent = new CountDownLatch(1);
+		Disposable disposable = agent.streamMessages(new UserMessage("please look up x"), config)
+				.doOnNext(message -> firstEvent.countDown())
+				.subscribe();
+		assertTrue(firstEvent.await(5, TimeUnit.SECONDS), "the stream should emit at least one event");
+		System.out.println("[T " + System.currentTimeMillis() + "] dispose on " + Thread.currentThread().getName());
+		disposable.dispose();
+		// Give any background persistence (the buggy path) time to land before inspecting.
+		Thread.sleep(2000);
+
+		saver.list(config).forEach(cp -> {
+			Object messages = cp.getState() == null ? null : cp.getState().get("messages");
+			System.out.println("[LIST] id=" + cp.getId().substring(0, 8) + " nodeId=" + cp.getNodeId() + " state=["
+					+ (messages instanceof List<?> list
+							? list.stream().map(m -> m instanceof Message msg ? msg.getMessageType().name() : "?")
+									.reduce((a, b) -> a + "," + b).orElse("<empty>")
+							: String.valueOf(messages)) + "]");
+		});
+		Checkpoint checkpoint = checkpointOf(saver, config);
+		if (checkpoint == null) {
+			return; // nothing persisted at all: the invariant trivially holds
+		}
+		assertToolCallPairsValid(checkpoint);
+	}
+
+	@Test
+	void disposingAfterCompletionKeepsTheFullTurn() throws Exception {
+		MemorySaver saver = new MemorySaver();
+		ReactAgent agent = agentWith(saver, "issue25_completed_agent");
+		RunnableConfig config = RunnableConfig.builder().threadId("issue25-completed").build();
+
+		CountDownLatch completed = new CountDownLatch(1);
+		Disposable disposable = agent.streamMessages(new UserMessage("please look up x"), config)
+				.doOnComplete(() -> completed.countDown())
+				.subscribe();
+		assertTrue(completed.await(10, TimeUnit.SECONDS), "the run should complete");
+		disposable.dispose(); // no-op on a completed stream: no cancel signal, no rewind
+
+		Thread.sleep(200);
+		Checkpoint checkpoint = checkpointOf(saver, config);
+		assertNotNull(checkpoint);
+		assertToolCallPairsValid(checkpoint);
+		assertEquals(4, messagesOf(checkpoint).size(), "the completed turn must be fully recorded");
+	}
+
+	private static String describe(List<Message> messages) {
+		StringBuilder sb = new StringBuilder();
+		for (Message m : messages) {
+			if (sb.length() > 0) {
+				sb.append(" -> ");
+			}
+			sb.append(m.getMessageType());
+			if (m instanceof AssistantMessage a && !a.getToolCalls().isEmpty()) {
+				sb.append("(tool_call)");
+			}
+			if (m instanceof ToolResponseMessage) {
+				sb.append("(tool)");
+			}
+		}
+		return sb.toString();
+	}
+
+}

--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/ReactAgentRewindSubscriptionScopeTest.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/ReactAgentRewindSubscriptionScopeTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.agentic.spring.ai.graph.agent;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.github.agentic.spring.ai.graph.NodeOutput;
+import io.github.agentic.spring.ai.graph.RunnableConfig;
+import io.github.agentic.spring.ai.graph.checkpoint.BaseCheckpointSaver;
+import io.github.agentic.spring.ai.graph.checkpoint.Checkpoint;
+import io.github.agentic.spring.ai.graph.checkpoint.savers.MemorySaver;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.support.ToolCallbacks;
+import org.springframework.ai.tool.ToolCallback;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The cancellation rewind must capture its pre-turn snapshot at subscription
+ * time, not at Flux assembly time. Graph execution starts on subscribe, so a
+ * snapshot read while the Flux is being assembled goes stale: a state commit
+ * landing between assembly and subscription would be rolled back by a later
+ * cancellation, and every re-subscription of the cold Flux would reuse that
+ * same stale read.
+ */
+class ReactAgentRewindSubscriptionScopeTest {
+
+	private static final class LookupTools {
+
+		@Tool(description = "look up something")
+		public String lookup(@ToolParam(description = "the query") String query) {
+			return "result-for-" + query;
+		}
+
+	}
+
+	/**
+	 * Calls 1 and 2 return immediately with distinct answers; call 3 blocks until
+	 * released, so the third turn is reliably mid-flight when the test disposes.
+	 */
+	private static final class ScriptedChatModel implements ChatModel {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		private final CountDownLatch thirdCallEntered = new CountDownLatch(1);
+
+		private final CountDownLatch releaseThirdCall = new CountDownLatch(1);
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			int call = callCount.incrementAndGet();
+			if (call == 3) {
+				thirdCallEntered.countDown();
+				try {
+					releaseThirdCall.await(10, TimeUnit.SECONDS);
+				}
+				catch (InterruptedException ex) {
+					Thread.currentThread().interrupt();
+				}
+				return new ChatResponse(List.of(new Generation(new AssistantMessage("blocked-turn"))));
+			}
+			return new ChatResponse(List.of(new Generation(new AssistantMessage("answer-" + call))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+
+	}
+
+	private static final class SingleAnswerChatModel implements ChatModel {
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			return new ChatResponse(List.of(new Generation(new AssistantMessage("answer"))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+
+	}
+
+	private static final class CountingSaver implements BaseCheckpointSaver {
+
+		private final MemorySaver delegate;
+
+		private final AtomicInteger reads = new AtomicInteger();
+
+		CountingSaver(MemorySaver delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public Optional<Checkpoint> get(RunnableConfig config) {
+			reads.incrementAndGet();
+			return delegate.get(config);
+		}
+
+		@Override
+		public Collection<Checkpoint> list(RunnableConfig config) {
+			return delegate.list(config);
+		}
+
+		@Override
+		public BaseCheckpointSaver.Tag release(RunnableConfig config) throws Exception {
+			return delegate.release(config);
+		}
+
+		@Override
+		public RunnableConfig put(RunnableConfig config, Checkpoint checkpoint) throws Exception {
+			return delegate.put(config, checkpoint);
+		}
+
+	}
+
+	@SuppressWarnings("unchecked")
+	private static List<Message> messagesOf(Checkpoint checkpoint) {
+		Object messages = checkpoint.getState().get("messages");
+		return messages instanceof List<?> list ? (List<Message>) list : List.of();
+	}
+
+	@Test
+	void cancellationRewindsToSubscriptionTimeSnapshotNotAssemblyTime() throws Exception {
+		ScriptedChatModel model = new ScriptedChatModel();
+		ToolCallback lookup = ToolCallbacks.from(new LookupTools())[0];
+		MemorySaver saver = new MemorySaver();
+		ReactAgent agent = ReactAgent.builder()
+				.name("rewind_scope_agent")
+				.model(model)
+				.tools(lookup)
+				.saver(saver)
+				.build();
+		RunnableConfig config = RunnableConfig.builder().threadId("rewind-scope").build();
+
+		// Turn one completes: the thread commits [human, answer-1].
+		agent.streamMessages(new UserMessage("turn one"), config).collectList().block(Duration.ofSeconds(10));
+
+		// Assemble turn two's Flux WITHOUT subscribing to it.
+		Flux<NodeOutput> deferred = agent.stream("turn two", config);
+
+		// A full turn commits between assembly and subscription:
+		// [human, answer-1, human, answer-2].
+		agent.streamMessages(new UserMessage("turn three"), config).collectList().block(Duration.ofSeconds(10));
+
+		// Subscribe only now: the model call blocks until released, so the turn is
+		// reliably mid-flight when we dispose. The rewind must restore the
+		// subscription-time snapshot (the committed state containing answer-2),
+		// never the stale assembly-time one taken before turn three ran.
+		Disposable disposable = deferred.subscribe();
+		assertTrue(model.thirdCallEntered.await(10, TimeUnit.SECONDS), "the deferred stream should start on subscription");
+		disposable.dispose();
+		model.releaseThirdCall.countDown();
+		Thread.sleep(500);
+
+		Checkpoint checkpoint = saver.get(config).orElse(null);
+		assertNotNull(checkpoint, "the thread must remain addressable after the cancelled turn");
+		List<Message> messages = messagesOf(checkpoint);
+		assertEquals(4, messages.size(),
+				"cancellation must roll back to the subscription-time snapshot, not the stale assembly-time one");
+		Message last = messages.get(messages.size() - 1);
+		assertTrue(last instanceof AssistantMessage assistant && "answer-2".equals(assistant.getText()),
+				"the committed answer-2 turn must survive the cancellation: " + messages);
+	}
+
+	@Test
+	void snapshotIsCapturedPerSubscriptionNotAtAssemblyTime() throws Exception {
+		ToolCallback lookup = ToolCallbacks.from(new LookupTools())[0];
+		CountingSaver counting = new CountingSaver(new MemorySaver());
+		ReactAgent agent = ReactAgent.builder()
+				.name("rewind_timing_agent")
+				.model(new SingleAnswerChatModel())
+				.tools(lookup)
+				.saver(counting)
+				.build();
+		RunnableConfig config = RunnableConfig.builder().threadId("rewind-timing").build();
+
+		Flux<NodeOutput> deferred = agent.stream("turn one", config);
+		assertEquals(0, counting.reads.get(), "assembling the Flux must not read the checkpoint");
+
+		deferred.collectList().block(Duration.ofSeconds(10));
+		assertTrue(counting.reads.get() >= 1, "each subscription must capture its own pre-turn snapshot");
+	}
+
+}

--- a/agentic-spring-ai-graph-core/src/main/java/io/github/agentic/spring/ai/graph/GraphRunner.java
+++ b/agentic-spring-ai-graph-core/src/main/java/io/github/agentic/spring/ai/graph/GraphRunner.java
@@ -59,7 +59,10 @@ public class GraphRunner {
 				return mainGraphExecutor.execute(context, resultValue)
 					.expandDeep(response -> response.hasContinuation()
 							? Flux.defer(() -> response.getContinuation().get()) : Flux.empty())
-					.filter(response -> !response.hasContinuation());
+					.filter(response -> !response.hasContinuation())
+					// In-flight async node completions may still land after the subscriber
+					// cancels; from this point on they must not persist any checkpoint.
+					.doOnCancel(context::markCancelled);
 			}
 			catch (Exception e) {
 				return Flux.error(e);

--- a/agentic-spring-ai-graph-core/src/main/java/io/github/agentic/spring/ai/graph/GraphRunnerContext.java
+++ b/agentic-spring-ai-graph-core/src/main/java/io/github/agentic/spring/ai/graph/GraphRunnerContext.java
@@ -77,6 +77,22 @@ public class GraphRunnerContext {
 
 	String resumeFrom;
 
+	/**
+	 * Set when the downstream subscriber cancels the run. In-flight async node completions may
+	 * still land afterwards; once set, no further checkpoint must be persisted, so a cancelled
+	 * turn cannot leave a half-persisted fragment (e.g. a dangling assistant tool_call) that
+	 * would make the next turn's message sequence invalid (issue #25).
+	 */
+	private volatile boolean cancelled;
+
+	public void markCancelled() {
+		this.cancelled = true;
+	}
+
+	public boolean isCancelled() {
+		return cancelled;
+	}
+
 	ReturnFromEmbed returnFromEmbed;
 
 	public GraphRunnerContext(OverAllState initialState, RunnableConfig config, CompiledGraph compiledGraph)
@@ -251,9 +267,19 @@ public class GraphRunnerContext {
 	// ================================================================================================================
 
 	public Optional<Checkpoint> addCheckpoint(String nodeId, String nextNodeId) throws Exception {
+		if (cancelled) {
+			// The run was cancelled by the subscriber: in-flight completions must not persist
+			// any further state, otherwise a cancelled turn is only half-recorded (issue #25).
+			return Optional.empty();
+		}
 		if (compiledGraph.compileConfig.checkpointSaver().isPresent()) {
 			var cp = Checkpoint.builder().nodeId(nodeId).state(cloneState(overallState.data())).nextNodeId(nextNodeId)
 					.build();
+			// Re-check after the (potentially expensive) state clone: cancellation may have
+			// happened while this checkpoint was being built.
+			if (cancelled) {
+				return Optional.empty();
+			}
 			// Force checkPointId to null to ensure we append a new checkpoint instead of
 			// replacing the current one
 			RunnableConfig appendConfig = RunnableConfig.builder(config).checkPointId(null).build();


### PR DESCRIPTION
### Describe what this PR does / why we need it

When a subscriber cancels a streaming run — SSE disconnect, `flux.timeout`, debugger pause — the in-flight turn could end up **half-persisted** in the checkpoint. Two observed variants:

- a dangling `ASSISTANT(tool_call)` with no following tool response (reproduced offline in this repository, see test), or
- a `ToolResponseMessage` whose preceding assistant tool_call never got persisted (reported in the linked issue).

Either way, the *next* turn loads an invalid message sequence and mainstream LLM APIs reject the request with 400 ("roles must alternate…").

Root cause: state merge + checkpoint persistence sit in `processedFlux.concatWith(updateContextMono…)` inside `NodeExecutor.processGraphResponseFlux`, so they only run when downstream demand pulls the tail — cancellation skips them, while nested async continuations may still land their own checkpoints.

This PR makes a cancelled turn behave as if it never happened:

1. `GraphRunner.run` marks the `GraphRunnerContext` cancelled on the stream's `doOnCancel`; `addCheckpoint` skips persistence when cancelled — with a re-check after the (potentially expensive) state clone, so in-flight completions racing the cancel cannot record a half turn.
2. `ReactAgent.doStream` snapshots the thread's pre-turn checkpoint at assembly time and, on cancellation, rewinds the saver to that snapshot via `saver.put(config, Checkpoint.copyOf(...))` (an empty-state checkpoint for a first-ever turn).

Normal completion and error paths are untouched (`doOnCancel` does not fire on them).

### Does this pull request fix one issue?

Fixes #25

### Describe how you did it

- `GraphRunnerContext`: volatile `cancelled` flag + `markCancelled()`; `addCheckpoint` early-returns when cancelled (checked on entry and again right before the saver put).
- `GraphRunner.run`: attaches `doOnCancel(context::markCancelled)`.
- `ReactAgent.doStream` override: pre-turn checkpoint snapshot + `doOnCancel` rewind; rewind failures are logged-and-swallowed so they never mask the cancellation.
- `Issue25StreamCancelCheckpointTest` (offline, stub streaming model + tool + `MemorySaver`):
  - full run persists a valid paired sequence (baseline);
  - cancelling mid-turn leaves no dangling fragment — after the fix the checkpoint is rewound to the pre-turn state (against `main` this test fails with `USER -> ASSISTANT(tool_call)`);
  - disposing after completion keeps the full 4-message turn (guards against over-rewinding).

### Describe how to verify it

```
mvn -pl agentic-spring-ai-agent-framework -am test -Dtest=Issue25StreamCancelCheckpointTest
```

Full module suite (`mvn -pl agentic-spring-ai-agent-framework -am test`, 649 tests) shows the same failure set as unmodified `main` (the pre-existing Windows symlink-privilege tests in `FilesystemInterceptorTest` / `FileSystemToolsTest`); no new failures.

### Special notes for reviewers

Design note: rewinding to the turn boundary was chosen over salvage-on-cancel (cannot fix the dangling tool_call variant) and load-time sequence sanitization (masks the problem, silently rewrites history). A design summary was posted on issue #25 before this PR. Scope note: the rewind is wired at the `Agent` streaming layer; generalizing the cancelled-flag handling to other entry points can follow if the approach looks right.
