### PR TITLE
feat(graph): mark reasoning chunks in agent model streaming

### DIFF
--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/Issue34ReasoningMarkerTest.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/Issue34ReasoningMarkerTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.agentic.spring.ai.graph.agent;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.github.agentic.spring.ai.graph.GraphRunnerContext;
+import io.github.agentic.spring.ai.graph.NodeOutput;
+import io.github.agentic.spring.ai.graph.RunnableConfig;
+import io.github.agentic.spring.ai.graph.streaming.OutputType;
+import io.github.agentic.spring.ai.graph.streaming.StreamingOutput;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import reactor.core.publisher.Flux;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the reasoning-phase marker for streamed model chunks (issue #34): during
+ * {@code AGENT_MODEL_STREAMING}, thinking chunks (blank content carrying reasoningContent)
+ * are stamped {@code isReasoning=true} and answer chunks {@code isReasoning=false}, so
+ * consumers can route the two phases without guessing.
+ */
+class Issue34ReasoningMarkerTest {
+
+	private static final class ReasoningThenAnswerChatModel implements ChatModel {
+
+		private final AtomicInteger callCount = new AtomicInteger();
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			return new ChatResponse(List.of(new Generation(new AssistantMessage("final answer"))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			if (callCount.incrementAndGet() == 1) {
+				return Flux.just(
+						new ChatResponse(List.of(new Generation(AssistantMessage.builder()
+							.content("")
+							.properties(Map.of("reasoningContent", "thinking hard about the query"))
+							.build()))),
+						new ChatResponse(List.of(new Generation(new AssistantMessage("final answer")))));
+			}
+			return Flux.just(new ChatResponse(List.of(new Generation(new AssistantMessage("done")))));
+		}
+
+	}
+
+	@Test
+	void reasoningAndAnswerChunksAreStampedExplicitly() throws Exception {
+		ReactAgent agent = ReactAgent.builder()
+				.name("issue34_agent")
+				.model(new ReasoningThenAnswerChatModel())
+				.build();
+
+		List<NodeOutput> outputs = agent
+				.stream("please answer", RunnableConfig.builder().threadId("issue34").build())
+				.collectList()
+				.block(Duration.ofSeconds(10));
+
+		assertNotNull(outputs);
+		assertTrue(outputs.size() >= 2, "the model stream should emit at least a reasoning and an answer chunk");
+
+		boolean sawReasoningChunk = false;
+		boolean sawAnswerChunk = false;
+		boolean lastChunkWasAnswer = false;
+		int agentModelChunks = 0;
+
+		for (NodeOutput output : outputs) {
+			if (!(output instanceof StreamingOutput<?> chunk)
+					|| chunk.getOutputType() != OutputType.AGENT_MODEL_STREAMING) {
+				continue;
+			}
+			agentModelChunks++;
+			Message message = chunk.message();
+			assertNotNull(message);
+			Object marker = message.getMetadata().get(GraphRunnerContext.IS_REASONING_METADATA_KEY);
+			assertInstanceOf(Boolean.class, marker,
+					"every AGENT_MODEL_STREAMING chunk must carry an explicit isReasoning marker, got metadata="
+							+ message.getMetadata());
+			if (Boolean.TRUE.equals(marker)) {
+				sawReasoningChunk = true;
+				assertEquals("", message.getText(), "a reasoning chunk carries no visible answer text");
+				assertEquals("thinking hard about the query",
+						message.getMetadata().get(GraphRunnerContext.REASONING_CONTENT_METADATA_KEY),
+						"the reasoning text must be preserved as metadata");
+			}
+			else {
+				sawAnswerChunk = true;
+			}
+			lastChunkWasAnswer = Boolean.FALSE.equals(marker);
+		}
+
+		assertTrue(agentModelChunks >= 2, "expected at least two AGENT_MODEL_STREAMING chunks");
+		assertTrue(sawReasoningChunk, "the reasoning chunk must be stamped isReasoning=true");
+		assertTrue(sawAnswerChunk, "the answer chunk must be stamped isReasoning=false");
+		assertTrue(lastChunkWasAnswer, "the last chunk must belong to the answer phase");
+	}
+
+}

--- a/agentic-spring-ai-graph-core/src/main/java/io/github/agentic/spring/ai/graph/GraphRunnerContext.java
+++ b/agentic-spring-ai-graph-core/src/main/java/io/github/agentic/spring/ai/graph/GraphRunnerContext.java
@@ -29,8 +29,10 @@ import io.github.agentic.spring.ai.graph.streaming.StreamingOutput;
 import io.github.agentic.spring.ai.graph.utils.SystemClock;
 import io.github.agentic.spring.ai.graph.utils.TypeRef;
 
+import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.metadata.Usage;
+import org.springframework.ai.deepseek.DeepSeekAssistantMessage;
 
 import org.springframework.util.CollectionUtils;
 
@@ -278,10 +280,57 @@ public class GraphRunnerContext {
 	public StreamingOutput<?> buildStreamingOutput(Message message, Object originData, String nodeId, boolean streaming) {
 		// Create StreamingOutput with chunk and originData
 		OutputType outputType = OutputType.from(streaming, nodeId);
+		// Reasoning models stream the thinking phase as blank-content chunks carrying
+		// reasoningContent; stamp an explicit marker so consumers can route thinking vs
+		// final-answer chunks (issue #34).
+		if (outputType == OutputType.AGENT_MODEL_STREAMING) {
+			message = stampReasoningMarker(message);
+		}
 		StreamingOutput<?> output = new StreamingOutput<>(message, originData, nodeId,
 				(String) config.metadata("_AGENT_").orElse(""), this.overallState, outputType);
 		output.setSubGraph(true);
 		return output;
+	}
+
+	/**
+	 * Metadata key marking whether a streamed model chunk belongs to the reasoning (thinking)
+	 * phase rather than the final answer.
+	 */
+	public static final String IS_REASONING_METADATA_KEY = "isReasoning";
+
+	/**
+	 * Metadata key carrying the reasoning (thinking) text of a chunk, normalized from either
+	 * the message metadata or a {@link DeepSeekAssistantMessage}.
+	 */
+	public static final String REASONING_CONTENT_METADATA_KEY = "reasoningContent";
+
+	private Message stampReasoningMarker(Message message) {
+		if (!(message instanceof AssistantMessage assistantMessage)) {
+			return message;
+		}
+		String reasoningContent = extractReasoningContent(assistantMessage);
+		boolean isReasoning = reasoningContent != null && !reasoningContent.isBlank()
+				&& (assistantMessage.getText() == null || assistantMessage.getText().isEmpty());
+		Map<String, Object> metadata = new HashMap<>(assistantMessage.getMetadata() != null
+				? assistantMessage.getMetadata() : Map.of());
+		metadata.put(IS_REASONING_METADATA_KEY, isReasoning);
+		if (reasoningContent != null) {
+			metadata.putIfAbsent(REASONING_CONTENT_METADATA_KEY, reasoningContent);
+		}
+		return AssistantMessage.builder()
+				.content(assistantMessage.getText())
+				.properties(metadata)
+				.toolCalls(assistantMessage.getToolCalls())
+				.media(assistantMessage.getMedia())
+				.build();
+	}
+
+	private static String extractReasoningContent(Message message) {
+		if (message instanceof DeepSeekAssistantMessage deepSeekAssistantMessage) {
+			return deepSeekAssistantMessage.getReasoningContent();
+		}
+		Object reasoningContent = message.getMetadata().get(REASONING_CONTENT_METADATA_KEY);
+		return reasoningContent != null ? reasoningContent.toString() : null;
 	}
 
 	public StreamingOutput<?> buildStreamingOutput(Object originData, String nodeId, boolean streaming) {

--- a/agentic-spring-ai-graph-core/src/main/java/io/github/agentic/spring/ai/graph/GraphRunnerContext.java
+++ b/agentic-spring-ai-graph-core/src/main/java/io/github/agentic/spring/ai/graph/GraphRunnerContext.java
@@ -32,7 +32,6 @@ import io.github.agentic.spring.ai.graph.utils.TypeRef;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.metadata.Usage;
-import org.springframework.ai.deepseek.DeepSeekAssistantMessage;
 
 import org.springframework.util.CollectionUtils;
 
@@ -300,9 +299,17 @@ public class GraphRunnerContext {
 
 	/**
 	 * Metadata key carrying the reasoning (thinking) text of a chunk, normalized from either
-	 * the message metadata or a {@link DeepSeekAssistantMessage}.
+	 * the message metadata or a DeepSeek assistant message (optional dependency).
 	 */
 	public static final String REASONING_CONTENT_METADATA_KEY = "reasoningContent";
+
+	/**
+	 * Class name of the optional DeepSeek assistant message. Resolved reflectively so
+	 * runtimes without the {@code spring-ai-deepseek} jar never force the class to link:
+	 * an {@code instanceof} against it throws {@link NoClassDefFoundError} on the first
+	 * streamed chunk for applications that do not carry the DeepSeek dependency.
+	 */
+	private static final String DEEPSEEK_ASSISTANT_MESSAGE_CLASS = "org.springframework.ai.deepseek.DeepSeekAssistantMessage";
 
 	private Message stampReasoningMarker(Message message) {
 		if (!(message instanceof AssistantMessage assistantMessage)) {
@@ -326,11 +333,24 @@ public class GraphRunnerContext {
 	}
 
 	private static String extractReasoningContent(Message message) {
-		if (message instanceof DeepSeekAssistantMessage deepSeekAssistantMessage) {
-			return deepSeekAssistantMessage.getReasoningContent();
-		}
 		Object reasoningContent = message.getMetadata().get(REASONING_CONTENT_METADATA_KEY);
-		return reasoningContent != null ? reasoningContent.toString() : null;
+		if (reasoningContent != null) {
+			return reasoningContent.toString();
+		}
+		// Compare class names instead of instanceof: a name check never links the
+		// optional DeepSeek class, so plain AssistantMessage streams stay safe on
+		// runtimes without the jar (mirrors the optional-serializer guards).
+		if (!message.getClass().getName().equals(DEEPSEEK_ASSISTANT_MESSAGE_CLASS)) {
+			return null;
+		}
+		try {
+			Class<?> deepSeekClass = Class.forName(DEEPSEEK_ASSISTANT_MESSAGE_CLASS, false, message.getClass().getClassLoader());
+			return (String) deepSeekClass.getMethod("getReasoningContent").invoke(message);
+		}
+		catch (ReflectiveOperationException | RuntimeException ex) {
+			// Class present but unusable, or reflective access refused: no reasoning content.
+			return null;
+		}
 	}
 
 	public StreamingOutput<?> buildStreamingOutput(Object originData, String nodeId, boolean streaming) {

--- a/spring-boot-starters/agentic-spring-ai-starter-graph-observation/src/test/java/io/github/agentic/spring/ai/autoconfigure/graph/GraphRunnerContextNoDeepSeekRuntimeTest.java
+++ b/spring-boot-starters/agentic-spring-ai-starter-graph-observation/src/test/java/io/github/agentic/spring/ai/autoconfigure/graph/GraphRunnerContextNoDeepSeekRuntimeTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.agentic.spring.ai.autoconfigure.graph;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import io.github.agentic.spring.ai.graph.GraphRunnerContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for the optional {@code spring-ai-deepseek} dependency (PR #80).
+ *
+ * <p>This starter module depends on graph-core but carries no DeepSeek dependency at
+ * runtime, mirroring a downstream application that never installed DeepSeek. The
+ * reasoning-content extraction must therefore never force
+ * {@code DeepSeekAssistantMessage} to link: with the previous {@code instanceof}
+ * probe, the first streamed plain {@link AssistantMessage} chunk threw
+ * {@link NoClassDefFoundError}.
+ */
+class GraphRunnerContextNoDeepSeekRuntimeTest {
+
+	private static Method extractReasoningContent;
+
+	@BeforeAll
+	static void findExtractionMethod() throws Exception {
+		// Precondition guard: if a dependency change ever puts spring-ai-deepseek back
+		// on this module's runtime classpath, this test can no longer exercise the
+		// absence path and must not pass silently.
+		assertThrows(ClassNotFoundException.class,
+				() -> Class.forName("org.springframework.ai.deepseek.DeepSeekAssistantMessage", false,
+						GraphRunnerContextNoDeepSeekRuntimeTest.class.getClassLoader()),
+				"spring-ai-deepseek must be absent from this module's runtime classpath");
+		extractReasoningContent = GraphRunnerContext.class.getDeclaredMethod("extractReasoningContent", Message.class);
+		extractReasoningContent.setAccessible(true);
+	}
+
+	@Test
+	void plainAssistantMessageDoesNotForceDeepSeekClassLinkage() {
+		AssistantMessage plain = new AssistantMessage("ordinary answer");
+		String result = assertDoesNotThrow(() -> (String) extractReasoningContent.invoke(null, plain),
+				"reasoning extraction must not link the optional DeepSeek class");
+		assertNull(result);
+	}
+
+	@Test
+	void metadataCarriedReasoningContentIsExtractedWithoutDeepSeek() {
+		AssistantMessage withReasoning = AssistantMessage.builder()
+				.content("answer")
+				.properties(Map.of(GraphRunnerContext.REASONING_CONTENT_METADATA_KEY, "thinking..."))
+				.build();
+		String result = assertDoesNotThrow(() -> (String) extractReasoningContent.invoke(null, withReasoning));
+		assertEquals("thinking...", result);
+	}
+
+	@Test
+	void messageMetadataContractStaysIntact() {
+		// The metadata key constants are the public contract downstream consumers code against.
+		assertEquals("isReasoning", GraphRunnerContext.IS_REASONING_METADATA_KEY);
+		assertEquals("reasoningContent", GraphRunnerContext.REASONING_CONTENT_METADATA_KEY);
+		assertTrue(GraphRunnerContext.REASONING_CONTENT_METADATA_KEY.length() > 0);
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Reasoning models (DeepSeek, Qwen thinking mode, vLLM `--reasoning-parser` deployments) stream the thinking phase as chunks whose visible content is blank while the reasoning text arrives in `reasoningContent`. During `AGENT_MODEL_STREAMING` consumers had no reliable way to tell a thinking chunk from a final-answer chunk, so frontends cannot split "thinking…" from the answer (issue #34).

This PR stamps an explicit marker on the chunk message metadata while building the streaming output:

- every `AGENT_MODEL_STREAMING` chunk carries `isReasoning` (`true` for thinking chunks — blank content with non-blank reasoning text — and `false` otherwise), so consumers never need to guess from an absent key;
- the chunk's `reasoningContent` is normalized into the message metadata as well, covering both plain-metadata sources and `DeepSeekAssistantMessage` instances, so the reasoning text survives even though stamping rebuilds the message as a plain `AssistantMessage`;
- other output types (`AGENT_TOOL_*`, `AGENT_HOOK_*`, graph nodes) are untouched.

Works for both `stream()` (marker on `StreamingOutput.message`) and `streamMessages()` (marker travels with the extracted `Message`).

### Does this pull request fix one issue?

Fixes #34

### Describe how you did it

- `GraphRunnerContext.buildStreamingOutput(Message, ...)`: when the output type is `AGENT_MODEL_STREAMING`, stamp the message via a new `stampReasoningMarker` helper (detection + metadata rebuild, null-safe).
- New constants `IS_REASONING_METADATA_KEY` / `REASONING_CONTENT_METADATA_KEY` on `GraphRunnerContext` for consumers.
- `Issue34ReasoningMarkerTest`: stub streaming model emits a reasoning chunk then an answer chunk; asserts the explicit marker on both, the preserved reasoning text, and that the last chunk belongs to the answer phase.

### Describe how to verify it

```
mvn -pl agentic-spring-ai-agent-framework -am test -Dtest=Issue34ReasoningMarkerTest
```

### Special notes for reviewers

The stamping is applied to `AGENT_MODEL_STREAMING` only, matching the issue scope; extending it to other output types would be a small follow-up if wanted. The approach (metadata marker on the chunk message, per the issue reporter's suggestion) was posted on the issue before this PR — happy to adapt if a different carrier (e.g. a dedicated event type) is preferred.
