### PR TITLE
fix(a2a): preserve shared message type

### DIFF
--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/a2a/A2aNodeActionWithConfig.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/a2a/A2aNodeActionWithConfig.java
@@ -109,7 +109,7 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 			Map<String, Object> resultMap = autoDetectAndParseResponse(resultText);
 			Map<String, Object> result = (Map<String, Object>) resultMap.get("result");
 			String responseText = extractResponseText(result);
-			return Map.of(this.outputKeyToParent, responseText);
+			return buildFinalResult(this.outputKeyToParent, responseText);
 		}
 	}
 
@@ -312,7 +312,7 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 				queue.add(AsyncGenerator.Data.of(errorOutput));
 			}
 			finally {
-				queue.add(AsyncGenerator.Data.done(Map.of(outputKey, accumulated.toString())));
+				queue.add(AsyncGenerator.Data.done(buildFinalResult(outputKey, accumulated.toString())));
 			}
 		});
 	}
@@ -377,14 +377,14 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 				}
 
 				// Signal completion with final result value
-				queue.add(AsyncGenerator.Data.done(Map.of(outputKey, accumulated.toString())));
+				queue.add(AsyncGenerator.Data.done(buildFinalResult(outputKey, accumulated.toString())));
 
 			}
 			catch (Exception e) {
 				// On error, emit an error message and signal completion
 				StreamingOutput errorOutput = buildStreamingOutput("Error: " + e.getMessage(), state);
 				queue.add(AsyncGenerator.Data.of(errorOutput));
-				queue.add(AsyncGenerator.Data.done(Map.of(outputKey, accumulated.toString())));
+				queue.add(AsyncGenerator.Data.done(buildFinalResult(outputKey, accumulated.toString())));
 			}
 		});
 	}
@@ -415,7 +415,7 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 		}
 
 		// Signal completion with final result value
-		queue.add(AsyncGenerator.Data.done(Map.of(outputKey, accumulated.toString())));
+		queue.add(AsyncGenerator.Data.done(buildFinalResult(outputKey, accumulated.toString())));
 
 		return new AsyncGeneratorQueue.Generator<>(queue);
 	}
@@ -435,6 +435,17 @@ public class A2aNodeActionWithConfig implements NodeActionWithConfig {
 	private StreamingOutput<?> buildStreamingOutput(String text, OverAllState state) {
 		return new StreamingOutput<>(new AssistantMessage(text), text, "a2aNode", agentName, state,
 				OutputType.AGENT_MODEL_STREAMING);
+	}
+
+	/**
+	 * Build the value written back to the parent graph while preserving the state key's type
+	 * contract. The {@code messages} key is managed by an append strategy and consumed as a
+	 * {@code List<Message>}; appending a raw string corrupts that list and causes routing agents to
+	 * fail on the next model call. Custom output keys retain their historical string value.
+	 */
+	private Map<String, Object> buildFinalResult(String outputKey, String text) {
+		Object value = "messages".equals(outputKey) ? new AssistantMessage(text) : text;
+		return Map.of(outputKey, value);
 	}
 
 	/**

--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/a2a/A2aLlmRoutingAgentShareStateTests.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/a2a/A2aLlmRoutingAgentShareStateTests.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.agentic.spring.ai.graph.agent.a2a;
+
+import io.github.agentic.spring.ai.graph.OverAllState;
+import io.github.agentic.spring.ai.graph.RunnableConfig;
+import io.github.agentic.spring.ai.graph.agent.flow.agent.LlmRoutingAgent;
+import io.github.agentic.spring.ai.graph.checkpoint.savers.MemorySaver;
+import io.a2a.spec.AgentCapabilities;
+import io.a2a.spec.AgentCard;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Regression tests for agentic-spring-ai#47 / spring-ai-alibaba#4015. */
+class A2aLlmRoutingAgentShareStateTests {
+
+	@Test
+	void sharedA2aRepliesRemainMessagesAcrossRoutingInvocations() throws Exception {
+		AtomicInteger remoteRequests = new AtomicInteger();
+		HttpServer server = createA2aServer(remoteRequests);
+		server.start();
+		try {
+			String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+			CapturingRoutingChatModel routingModel = new CapturingRoutingChatModel("remote_agent");
+			A2aRemoteAgent remoteAgent = A2aRemoteAgent.builder()
+					.name("remote_agent")
+					.description("Remote test agent")
+					.agentCard(createAgentCard(baseUrl))
+					.outputKey("messages")
+					.shareState(true)
+					.build();
+			LlmRoutingAgent routingAgent = LlmRoutingAgent.builder()
+					.name("routing_agent")
+					.description("Routes requests to the remote agent")
+					.model(routingModel)
+					.subAgents(List.of(remoteAgent))
+					.saver(new MemorySaver())
+					.build();
+			RunnableConfig config = RunnableConfig.builder().threadId("issue-47-thread").build();
+
+			Optional<OverAllState> firstResult = routingAgent.invoke("first request", config);
+			Optional<OverAllState> secondResult = routingAgent.invoke("second request", config);
+
+			assertTrue(firstResult.isPresent());
+			assertTrue(secondResult.isPresent());
+			assertEquals(2, remoteRequests.get());
+			assertEquals(2, routingModel.prompts().size());
+			assertTrue(routingModel.prompts().get(1).getInstructions().stream()
+					.anyMatch(message -> message instanceof AssistantMessage
+							&& "remote reply 1".equals(message.getText())));
+
+			@SuppressWarnings("unchecked")
+			List<Object> messages = (List<Object>) secondResult.orElseThrow().value("messages").orElseThrow();
+			assertTrue(messages.stream().allMatch(Message.class::isInstance));
+			AssistantMessage lastMessage = assertInstanceOf(AssistantMessage.class, messages.get(messages.size() - 1));
+			assertEquals("remote reply 2", lastMessage.getText());
+		}
+		finally {
+			server.stop(0);
+		}
+	}
+
+	private static HttpServer createA2aServer(AtomicInteger requests) throws Exception {
+		HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+		server.createContext("/", exchange -> {
+			int requestNumber = requests.incrementAndGet();
+			String response = """
+					{"jsonrpc":"2.0","id":"response-%d","result":{"kind":"artifact-update","artifact":{"parts":[{"text":"remote reply %d"}]}}}
+					""".formatted(requestNumber, requestNumber);
+			byte[] bytes = response.getBytes(StandardCharsets.UTF_8);
+			exchange.getResponseHeaders().add("Content-Type", "application/json");
+			exchange.sendResponseHeaders(200, bytes.length);
+			exchange.getResponseBody().write(bytes);
+			exchange.close();
+		});
+		return server;
+	}
+
+	private static AgentCard createAgentCard(String baseUrl) {
+		AgentCard agentCard = mock(AgentCard.class);
+		AgentCapabilities capabilities = mock(AgentCapabilities.class);
+		when(capabilities.streaming()).thenReturn(false);
+		when(agentCard.name()).thenReturn("remote_agent");
+		when(agentCard.url()).thenReturn(baseUrl);
+		when(agentCard.capabilities()).thenReturn(capabilities);
+		return agentCard;
+	}
+
+	private static final class CapturingRoutingChatModel implements ChatModel {
+
+		private final String response;
+
+		private final java.util.ArrayList<Prompt> prompts = new java.util.ArrayList<>();
+
+		private CapturingRoutingChatModel(String agentName) {
+			this.response = "{\"agents\":[{\"agent\":\"" + agentName + "\",\"query\":\"delegate\"}]}";
+		}
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			this.prompts.add(prompt);
+			return new ChatResponse(List.of(new Generation(new AssistantMessage(this.response))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+
+		private List<Prompt> prompts() {
+			return List.copyOf(this.prompts);
+		}
+	}
+
+}

--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/a2a/A2aNodeActionWithConfigTests.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/a2a/A2aNodeActionWithConfigTests.java
@@ -154,7 +154,7 @@ class A2aNodeActionWithConfigTests {
 	}
 
 	@Test
-	void applyDoesNotWriteNonStreamingPayloadToStdout() throws Exception {
+	void applyPreservesNonStreamingOutputContractAndDoesNotWritePayloadToStdout() throws Exception {
 		HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
 		server.createContext("/", exchange -> {
 			String response = """
@@ -177,8 +177,14 @@ class A2aNodeActionWithConfigTests {
 
 			Map<String, Object> result = nonStreamingAction.apply(new OverAllState(),
 					RunnableConfig.builder().threadId("thread-1").build());
+			A2aNodeActionWithConfig messagesAction = new A2aNodeActionWithConfig(createAgentCardWrapper(baseUrl),
+					"remote-agent", false, "messages", "secret instruction", false);
+			Map<String, Object> messagesResult = messagesAction.apply(new OverAllState(),
+					RunnableConfig.builder().threadId("thread-1").build());
 
 			assertEquals("remote ok", result.get("reply"));
+			AssistantMessage message = assertInstanceOf(AssistantMessage.class, messagesResult.get("messages"));
+			assertEquals("remote ok", message.getText());
 			assertEquals("", stdout.toString(StandardCharsets.UTF_8));
 		}
 		finally {
@@ -384,6 +390,8 @@ class A2aNodeActionWithConfigTests {
 
 	private static final Method BUILD_STREAMING_OUTPUT = initBuildStreamingOutputMethod();
 
+	private static final Method BUILD_FINAL_RESULT = initBuildFinalResultMethod();
+
 	/**
 	 * The studio chat UI renders streaming text from the {@code chunk} / {@code message} fields of
 	 * {@link StreamingOutput}. Before gh-4760, A2A streaming events were built with the plain
@@ -407,10 +415,47 @@ class A2aNodeActionWithConfigTests {
 		assertEquals(OutputType.AGENT_MODEL_STREAMING, output.getOutputType());
 	}
 
+	/**
+	 * Regression test for agentic-spring-ai#47 / spring-ai-alibaba#4015. A2A responses targeting
+	 * the shared messages key must be appended as Message instances, otherwise the next routing
+	 * decision encounters a String in List&lt;Message&gt; and fails with ClassCastException.
+	 */
+	@Test
+	void buildFinalResult_wrapsMessagesOutputInAssistantMessage() throws Exception {
+		Map<String, Object> result = invokeBuildFinalResult("messages", "remote reply");
+
+		AssistantMessage message = assertInstanceOf(AssistantMessage.class, result.get("messages"));
+		assertEquals("remote reply", message.getText());
+	}
+
+	@Test
+	void buildFinalResult_keepsCustomOutputAsString() throws Exception {
+		Map<String, Object> result = invokeBuildFinalResult("reply", "remote reply");
+
+		assertEquals("remote reply", result.get("reply"));
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> invokeBuildFinalResult(String outputKey, String text) throws Exception {
+		return (Map<String, Object>) BUILD_FINAL_RESULT.invoke(this.action, outputKey, text);
+	}
+
 	private static Method initBuildStreamingOutputMethod() {
 		try {
 			Method method = A2aNodeActionWithConfig.class.getDeclaredMethod("buildStreamingOutput", String.class,
 					OverAllState.class);
+			method.setAccessible(true);
+			return method;
+		}
+		catch (NoSuchMethodException ex) {
+			throw new IllegalStateException(ex);
+		}
+	}
+
+	private static Method initBuildFinalResultMethod() {
+		try {
+			Method method = A2aNodeActionWithConfig.class.getDeclaredMethod("buildFinalResult", String.class,
+					String.class);
 			method.setAccessible(true);
 			return method;
 		}


### PR DESCRIPTION
### Describe what this PR does / why we need it

A2A remote-agent responses configured with `outputKey("messages")` were written to shared state as raw strings. Since routing agents consume the `messages` state as a `List<Message>`, the next routing invocation could fail with a `String` to `Message` `ClassCastException`.

This change preserves the state key contract by writing A2A responses as `AssistantMessage` instances when the output key is `messages`. Custom output keys retain their existing string values.

The conversion is applied consistently to non-streaming responses and all streaming completion paths.

### Does this pull request fix one issue?

Fixes #47

### Describe how you did it

- Added a centralized final-result builder in `A2aNodeActionWithConfig`.
- Wrapped responses targeting `messages` in `AssistantMessage`.
- Preserved string output for custom output keys.
- Added an end-to-end regression test using a local HTTP A2A server, a deterministic routing `ChatModel`, `MemorySaver`, and two consecutive `LlmRoutingAgent` invocations.
- Verified that the second routing invocation reads the first A2A reply as an `AssistantMessage` and that shared message history contains only `Message` instances.

### Describe how to verify it

Run:

`./mvnw -pl :agentic-spring-ai-agent-framework -am -Dtest=A2aLlmRoutingAgentShareStateTests,A2aNodeActionWithConfigTests,A2aRemoteAgentTests,RoutingMergeNodeTest -Dsurefire.failIfNoSpecifiedTests=false test`

Result:

- Tests run: 30
- Failures: 0
- Errors: 0
- Skipped: 0
- BUILD SUCCESS

A full `./mvnw clean package` was also attempted. All A2A and routing tests passed, but the Windows environment could not create symbolic links required by existing filesystem tests. Database container tests were skipped because Docker was unavailable.

### Special notes for reviews

This change does not modify public APIs or the default A2A output key. Custom output keys continue to return strings; only the reserved `messages` key is converted to an `AssistantMessage`.