### PR TITLE
feat(agent): support custom interruptable model hooks

### DIFF
--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/ReactAgent.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/ReactAgent.java
@@ -30,15 +30,14 @@ import io.github.agentic.spring.ai.graph.action.NodeActionWithConfig;
 import io.github.agentic.spring.ai.graph.agent.exception.AgentException;
 import io.github.agentic.spring.ai.graph.agent.factory.AgentBuilderFactory;
 import io.github.agentic.spring.ai.graph.agent.factory.DefaultAgentBuilderFactory;
+import io.github.agentic.spring.ai.graph.agent.hook.AbstractInterruptableModelHook;
 import io.github.agentic.spring.ai.graph.agent.hook.AgentHook;
 import io.github.agentic.spring.ai.graph.agent.hook.Hook;
 import io.github.agentic.spring.ai.graph.agent.hook.HookPosition;
 import io.github.agentic.spring.ai.graph.agent.hook.InstructionAgentHook;
-import io.github.agentic.spring.ai.graph.agent.hook.InterruptionHook;
 import io.github.agentic.spring.ai.graph.agent.hook.JumpTo;
 import io.github.agentic.spring.ai.graph.agent.hook.ModelHook;
 import io.github.agentic.spring.ai.graph.agent.hook.ToolInjection;
-import io.github.agentic.spring.ai.graph.agent.hook.hip.HumanInTheLoopHook;
 import io.github.agentic.spring.ai.graph.agent.hook.messages.MessagesAgentHook;
 import io.github.agentic.spring.ai.graph.agent.hook.messages.MessagesModelHook;
 import io.github.agentic.spring.ai.graph.agent.hook.returndirect.ReturnDirectModelHook;
@@ -435,12 +434,10 @@ public class ReactAgent extends BaseAgent {
 
 		// Add hook nodes for beforeModel hooks
 		for (Hook hook : beforeModelHooks) {
-			if (hook instanceof ModelHook modelHook) {
-				if (hook instanceof InterruptionHook interruptionHook) {
-					graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", interruptionHook);
-				} else {
-					graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", modelHook::beforeModel);
-				}
+			if (hook instanceof AbstractInterruptableModelHook interruptableModelHook) {
+				graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", interruptableModelHook);
+			} else if (hook instanceof ModelHook modelHook) {
+				graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", modelHook::beforeModel);
 			} else if (hook instanceof MessagesModelHook messagesModelHook) {
 				graph.addNode(Hook.getFullHookName(hook) + ".beforeModel", MessagesModelHook.beforeModelAction(messagesModelHook));
 			}
@@ -448,12 +445,10 @@ public class ReactAgent extends BaseAgent {
 
 		// Add hook nodes for afterModel hooks
 		for (Hook hook : afterModelHooks) {
-			if (hook instanceof ModelHook modelHook) {
-				if (hook instanceof HumanInTheLoopHook humanInTheLoopHook) {
-					graph.addNode(Hook.getFullHookName(hook) + ".afterModel", humanInTheLoopHook);
-				} else {
-					graph.addNode(Hook.getFullHookName(hook) + ".afterModel", modelHook::afterModel);
-				}
+			if (hook instanceof AbstractInterruptableModelHook interruptableModelHook) {
+				graph.addNode(Hook.getFullHookName(hook) + ".afterModel", interruptableModelHook);
+			} else if (hook instanceof ModelHook modelHook) {
+				graph.addNode(Hook.getFullHookName(hook) + ".afterModel", modelHook::afterModel);
 			} else if (hook instanceof MessagesModelHook messagesModelHook) {
 				graph.addNode(Hook.getFullHookName(hook) + ".afterModel", MessagesModelHook.afterModelAction(messagesModelHook));
 			}

--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/hook/AbstractInterruptableModelHook.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/hook/AbstractInterruptableModelHook.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.agentic.spring.ai.graph.agent.hook;
+
+import io.github.agentic.spring.ai.graph.action.AsyncNodeActionWithConfig;
+import io.github.agentic.spring.ai.graph.action.InterruptableAction;
+
+/**
+ * Base class for model hooks that need to participate in graph interruption as full
+ * graph nodes. Subclasses implement {@link AsyncNodeActionWithConfig#apply} to define
+ * the node action.
+ */
+public abstract class AbstractInterruptableModelHook extends ModelHook
+		implements AsyncNodeActionWithConfig, InterruptableAction {
+
+}

--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/hook/InterruptionHook.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/hook/InterruptionHook.java
@@ -18,8 +18,6 @@ package io.github.agentic.spring.ai.graph.agent.hook;
 import io.github.agentic.spring.ai.graph.KeyStrategy;
 import io.github.agentic.spring.ai.graph.OverAllState;
 import io.github.agentic.spring.ai.graph.RunnableConfig;
-import io.github.agentic.spring.ai.graph.action.AsyncNodeActionWithConfig;
-import io.github.agentic.spring.ai.graph.action.InterruptableAction;
 import io.github.agentic.spring.ai.graph.action.InterruptionMetadata;
 import io.github.agentic.spring.ai.graph.state.strategy.ReplaceStrategy;
 
@@ -48,7 +46,7 @@ import static io.github.agentic.spring.ai.graph.checkpoint.BaseCheckpointSaver.T
  * InterruptionHook hook = InterruptionHook.builder().build();
  */
 @HookPositions({HookPosition.BEFORE_MODEL})
-public class InterruptionHook extends ModelHook implements AsyncNodeActionWithConfig, InterruptableAction {
+public class InterruptionHook extends AbstractInterruptableModelHook {
 	private static final Logger log = LoggerFactory.getLogger(InterruptionHook.class);
 	
 	public static final String INTERRUPTION_FEEDBACK_KEY = "INTERRUPTION_FEEDBACK";
@@ -200,4 +198,3 @@ public class InterruptionHook extends ModelHook implements AsyncNodeActionWithCo
 		}
 	}
 }
-

--- a/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/hook/hip/HumanInTheLoopHook.java
+++ b/agentic-spring-ai-agent-framework/src/main/java/io/github/agentic/spring/ai/graph/agent/hook/hip/HumanInTheLoopHook.java
@@ -17,16 +17,14 @@ package io.github.agentic.spring.ai.graph.agent.hook.hip;
 
 import io.github.agentic.spring.ai.graph.OverAllState;
 import io.github.agentic.spring.ai.graph.RunnableConfig;
-import io.github.agentic.spring.ai.graph.action.AsyncNodeActionWithConfig;
-import io.github.agentic.spring.ai.graph.action.InterruptableAction;
 import io.github.agentic.spring.ai.graph.action.InterruptionMetadata;
+import io.github.agentic.spring.ai.graph.agent.hook.AbstractInterruptableModelHook;
 import io.github.agentic.spring.ai.graph.action.InterruptionMetadata.ToolFeedback;
 import io.github.agentic.spring.ai.graph.action.InterruptionMetadata.ToolFeedback.FeedbackResult;
 import io.github.agentic.spring.ai.graph.agent.hook.Hook;
 import io.github.agentic.spring.ai.graph.agent.hook.HookPosition;
 import io.github.agentic.spring.ai.graph.agent.hook.HookPositions;
 import io.github.agentic.spring.ai.graph.agent.hook.JumpTo;
-import io.github.agentic.spring.ai.graph.agent.hook.ModelHook;
 import io.github.agentic.spring.ai.graph.state.RemoveByHash;
 import io.github.agentic.spring.ai.graph.utils.TypeRef;
 
@@ -45,7 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @HookPositions(HookPosition.AFTER_MODEL)
-public class HumanInTheLoopHook extends ModelHook implements AsyncNodeActionWithConfig, InterruptableAction {
+public class HumanInTheLoopHook extends AbstractInterruptableModelHook {
 	private static final Logger log = LoggerFactory.getLogger(HumanInTheLoopHook.class);
     public static final String HITL_NODE_NAME = "HITL";
 	private Map<String, ToolConfig> approvalOn;

--- a/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/hooks/AbstractInterruptableModelHookTest.java
+++ b/agentic-spring-ai-agent-framework/src/test/java/io/github/agentic/spring/ai/graph/agent/hooks/AbstractInterruptableModelHookTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.agentic.spring.ai.graph.agent.hooks;
+
+import io.github.agentic.spring.ai.graph.OverAllState;
+import io.github.agentic.spring.ai.graph.RunnableConfig;
+import io.github.agentic.spring.ai.graph.agent.ReactAgent;
+import io.github.agentic.spring.ai.graph.agent.hook.AbstractInterruptableModelHook;
+import io.github.agentic.spring.ai.graph.agent.hook.HookPosition;
+import io.github.agentic.spring.ai.graph.agent.hook.HookPositions;
+import io.github.agentic.spring.ai.graph.action.InterruptionMetadata;
+
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.model.Generation;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AbstractInterruptableModelHookTest {
+
+	@Test
+	void customInterruptableModelHookRunsAsFullGraphNode() throws Exception {
+		TestInterruptableModelHook hook = new TestInterruptableModelHook();
+		ReactAgent agent = ReactAgent.builder()
+				.name("custom-interruptable-hook-agent")
+				.model(new MockChatModel())
+				.hooks(hook)
+				.build();
+
+		agent.invoke("test");
+
+		assertTrue(hook.wasApplied(), "The custom interruptable hook should execute its node action");
+	}
+
+	@HookPositions(HookPosition.BEFORE_MODEL)
+	private static final class TestInterruptableModelHook extends AbstractInterruptableModelHook {
+
+		private final AtomicBoolean applied = new AtomicBoolean();
+
+		@Override
+		public String getName() {
+			return "test_interruptable_model_hook";
+		}
+
+		@Override
+		public CompletableFuture<Map<String, Object>> apply(OverAllState state, RunnableConfig config) {
+			applied.set(true);
+			return CompletableFuture.completedFuture(Map.of());
+		}
+
+		@Override
+		public Optional<InterruptionMetadata> interrupt(String nodeId, OverAllState state, RunnableConfig config) {
+			return Optional.empty();
+		}
+
+		boolean wasApplied() {
+			return applied.get();
+		}
+	}
+
+	private static final class MockChatModel implements ChatModel {
+
+		@Override
+		public ChatResponse call(Prompt prompt) {
+			return new ChatResponse(List.of(new Generation(new AssistantMessage("done"))));
+		}
+
+		@Override
+		public Flux<ChatResponse> stream(Prompt prompt) {
+			return Flux.just(call(prompt));
+		}
+	}
+
+}


### PR DESCRIPTION
### Describe what this PR does / why we need it

Custom model hooks that implement interruption semantics are currently registered through method references, which strips their InterruptableAction behavior. The framework also special-cases the two built-in interruption hooks, so third-party hooks cannot opt into the same graph-node behavior.

This ports the still-relevant change from alibaba/spring-ai-alibaba#4529 following maintainer guidance to contribute it here.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Added AbstractInterruptableModelHook as the shared base for model hooks requiring full node-action interruption semantics.
- Registered instances of that base class directly as graph nodes before or after the model.
- Migrated InterruptionHook and HumanInTheLoopHook to the shared base class.
- Added a regression test using a custom interruptable model hook.

### Describe how to verify it

./mvnw -pl :agentic-spring-ai-agent-framework -am -Dtest=AbstractInterruptableModelHookTest -Dsurefire.failIfNoSpecifiedTests=false test

Result: 1 test run, 0 failures, 0 errors; Checkstyle reports 0 violations.

### Special notes for reviews

The scope is intentionally limited to ReactAgent model-hook node registration and preserves the existing behavior of both built-in interruption hooks.